### PR TITLE
Make sidebar collapsible and add OpenAI settings page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -10,240 +10,314 @@
   <script src="https://code.iconify.design/iconify-icon/1.0.8/iconify-icon.min.js" defer></script>
   <link rel="stylesheet" href="style.css"/>
 </head>
-<body class="bg-slate-50">
-<div class="max-w-7xl mx-auto p-5 space-y-5">
-  <div class="flex items-center justify-between">
-    <div class="flex items-center gap-3">
-      <h1 class="text-xl font-bold">分类人工调整 GUI</h1>
-      <span id="app_ver" class="text-xs text-slate-500"></span>
-    </div>
-    <code id="session_badge" class="text-xs bg-slate-200 px-2 py-1 rounded">Session: —</code>
-  </div>
-
-  <!-- 顶部操作条：上传 / 会话保存 / 载入 / Excel 保存 -->
-  <div class="bg-white rounded-2xl shadow p-5">
-    <div class="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:items-end">
-      <div class="space-y-4">
-        <div class="space-y-2">
-          <label class="block text-sm font-medium text-slate-600">选择表格（.xlsx/.xls/.csv）</label>
-          <input id="file_input" class="file-input" type="file" accept=".xlsx,.xls,.csv">
-          <p class="text-xs text-slate-500">支持 Excel 与 CSV 文件，上传后将自动开启新的会话。</p>
+<body class="bg-slate-100">
+<div class="min-h-screen flex flex-col">
+  <header class="bg-white/90 backdrop-blur border-b border-slate-200">
+    <div class="max-w-7xl mx-auto px-6 py-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <div class="flex items-center gap-4">
+        <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-900 text-white text-lg font-semibold shadow-lg">CC</span>
+        <div>
+          <div class="flex flex-wrap items-center gap-3">
+            <h1 class="text-xl font-bold text-slate-900">分类人工调整工作台</h1>
+            <span id="app_ver" class="text-xs font-medium text-slate-500 bg-slate-100 border border-slate-200 rounded-full px-3 py-1"></span>
+          </div>
+          <p class="text-sm text-slate-500 mt-1">在统一界面完成编码流程与结果洞察。</p>
         </div>
-        <div class="flex flex-wrap items-center gap-3">
-          <button id="btn_upload" class="action-btn bg-blue-600 text-white hover:bg-blue-500 shadow-sm" title="上传并新建会话">
-            <iconify-icon icon="heroicons-outline:arrow-up-tray" class="w-5 h-5"></iconify-icon>
-            <span>上传并新建会话</span>
+      </div>
+      <div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+        <div class="hidden md:flex items-center gap-2 px-3 py-2 rounded-full bg-slate-100 text-slate-500 text-sm">
+          <iconify-icon icon="heroicons-outline:sparkles" class="w-5 h-5"></iconify-icon>
+          <span>智能分类助手随时待命</span>
+        </div>
+        <code id="session_badge" class="text-xs bg-slate-900 text-white px-3 py-1.5 rounded-full">Session: —</code>
+        <div class="md:hidden w-full">
+          <label class="sr-only" for="mobile_page_select">页面导航</label>
+          <select id="mobile_page_select" class="w-full border border-slate-200 rounded-xl px-3 py-2 text-sm text-slate-600 bg-white">
+            <option value="page-coding">编码工作台</option>
+            <option value="page-visual">数据可视化</option>
+            <option value="page-settings">OpenAI API 设置</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div class="flex flex-1">
+    <aside id="sidebar" class="hidden md:flex border-r border-slate-200 bg-white/80 backdrop-blur-sm transition-all duration-300" data-collapsed="false">
+      <div class="flex flex-col w-full h-full">
+        <div class="px-4 pt-6 pb-4 flex items-center justify-between">
+          <p class="nav-section-label text-xs font-semibold text-slate-400 uppercase tracking-wide">导航</p>
+          <button id="sidebar_toggle" class="sidebar-toggle" type="button" aria-expanded="true" aria-label="收起侧边栏" title="收起侧边栏">
+            <iconify-icon icon="heroicons-outline:chevron-left" class="w-5 h-5"></iconify-icon>
           </button>
-          <div class="flex-1 min-w-[200px]">
-            <div class="bg-slate-100 rounded-full h-2 overflow-hidden">
-              <div id="up_bar" class="bg-blue-600 h-2 w-0 transition-[width] duration-300"></div>
+        </div>
+        <nav class="flex-1 flex flex-col gap-2 px-2">
+          <button class="nav-link nav-link-active" data-target="page-coding" title="编码工作台" aria-label="编码工作台">
+            <iconify-icon icon="heroicons-outline:adjustments-horizontal" class="text-lg"></iconify-icon>
+            <span class="nav-label">编码工作台</span>
+          </button>
+          <button class="nav-link" data-target="page-visual" title="数据可视化" aria-label="数据可视化">
+            <iconify-icon icon="heroicons-outline:chart-pie" class="text-lg"></iconify-icon>
+            <span class="nav-label">数据可视化</span>
+          </button>
+        </nav>
+        <div class="sidebar-footer px-2 pt-4 pb-6 border-t border-slate-200">
+          <button class="nav-link" data-target="page-settings" title="OpenAI API 设置" aria-label="OpenAI API 设置">
+            <iconify-icon icon="heroicons-outline:cog-6-tooth" class="text-lg"></iconify-icon>
+            <span class="nav-label">OpenAI API 设置</span>
+          </button>
+        </div>
+      </div>
+    </aside>
+    <div class="flex-1 overflow-y-auto">
+      <main class="max-w-7xl mx-auto w-full px-6 py-8 space-y-10">
+        <section id="page-coding" class="page-section space-y-8">
+          <div class="bg-white rounded-2xl shadow p-6">
+            <div class="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:items-end">
+              <div class="space-y-4">
+                <div class="space-y-2">
+                  <label class="block text-sm font-medium text-slate-600">选择表格（.xlsx/.xls/.csv）</label>
+                  <input id="file_input" class="file-input" type="file" accept=".xlsx,.xls,.csv">
+                  <p class="text-xs text-slate-500">支持 Excel 与 CSV 文件，上传后将自动开启新的会话。</p>
+                </div>
+                <div class="flex flex-wrap items-center gap-3">
+                  <button id="btn_upload" class="action-btn bg-blue-600 text-white hover:bg-blue-500 shadow-sm" title="上传并新建会话">
+                    <iconify-icon icon="heroicons-outline:arrow-up-tray" class="w-5 h-5"></iconify-icon>
+                    <span>上传并新建会话</span>
+                  </button>
+                  <div class="flex-1 min-w-[200px]">
+                    <div class="bg-slate-100 rounded-full h-2 overflow-hidden">
+                      <div id="up_bar" class="bg-blue-600 h-2 w-0 transition-[width] duration-300"></div>
+                    </div>
+                  </div>
+                  <span id="up_msg" class="text-sm text-gray-600 whitespace-nowrap"></span>
+                </div>
+              </div>
+              <div class="info-card rounded-2xl p-5 space-y-4">
+                <div class="text-xs uppercase tracking-wide text-slate-500">会话与导出</div>
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <button id="btn_save_session" class="action-btn justify-center bg-emerald-600 text-white hover:bg-emerald-500 shadow-sm" title="将当前会话写入服务器磁盘（sessions/）">
+                    <iconify-icon icon="heroicons-outline:cloud-arrow-up" class="w-5 h-5"></iconify-icon>
+                    <span>保存会话</span>
+                  </button>
+                  <button id="btn_load_session" class="action-btn justify-center bg-slate-800 text-white hover:bg-slate-700 shadow-sm" title="从服务器读取会话">
+                    <iconify-icon icon="heroicons-outline:folder-arrow-down" class="w-5 h-5"></iconify-icon>
+                    <span>载入会话</span>
+                  </button>
+                  <button id="btn_save_excel" class="action-btn justify-center bg-indigo-600 text-white hover:bg-indigo-500 shadow-sm" title="写入 Output/<session>/export_*.xlsx">
+                    <iconify-icon icon="heroicons-outline:document-arrow-down" class="w-5 h-5"></iconify-icon>
+                    <span>保存 Excel</span>
+                  </button>
+                  <button id="btn_download_last" class="action-btn justify-center bg-slate-600 text-white hover:bg-slate-500 shadow-sm" title="从服务器下载最近一次导出副本（可选）">
+                    <iconify-icon icon="heroicons-outline:arrow-down-tray" class="w-5 h-5"></iconify-icon>
+                    <span>下载最新导出</span>
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
-          <span id="up_msg" class="text-sm text-gray-600 whitespace-nowrap"></span>
-        </div>
-      </div>
-      <div class="info-card rounded-2xl p-4 space-y-3">
-        <div class="text-xs uppercase tracking-wide text-slate-500">会话与导出</div>
-        <div class="grid gap-2 sm:grid-cols-2">
-          <button id="btn_save_session" class="action-btn justify-center bg-emerald-600 text-white hover:bg-emerald-500 shadow-sm" title="将当前会话写入服务器磁盘（sessions/）">
-            <iconify-icon icon="heroicons-outline:cloud-arrow-up" class="w-5 h-5"></iconify-icon>
-            <span>保存会话</span>
-          </button>
-          <button id="btn_load_session" class="action-btn justify-center bg-slate-800 text-white hover:bg-slate-700 shadow-sm" title="从服务器读取会话">
-            <iconify-icon icon="heroicons-outline:folder-arrow-down" class="w-5 h-5"></iconify-icon>
-            <span>载入会话</span>
-          </button>
-          <button id="btn_save_excel" class="action-btn justify-center bg-indigo-600 text-white hover:bg-indigo-500 shadow-sm" title="写入 Output/&lt;session&gt;/export_*.xlsx">
-            <iconify-icon icon="heroicons-outline:document-arrow-down" class="w-5 h-5"></iconify-icon>
-            <span>保存 Excel</span>
-          </button>
-          <button id="btn_download_last" class="action-btn justify-center bg-slate-600 text-white hover:bg-slate-500 shadow-sm" title="从服务器下载最近一次导出副本（可选）">
-            <iconify-icon icon="heroicons-outline:arrow-down-tray" class="w-5 h-5"></iconify-icon>
-            <span>下载最新导出</span>
-          </button>
-        </div>
-      </div>
+
+          <div class="bg-white rounded-2xl shadow p-6 space-y-3">
+            <div class="flex flex-wrap items-center gap-3">
+              <span class="text-sm">当前仅编辑：</span>
+              <select id="op_col_select" class="border rounded px-2 py-1">
+                <option value="topic">研究主题（调整）</option>
+                <option value="field">研究领域（调整）</option>
+              </select>
+              <span id="op_col_hint" class="text-xs text-gray-500">（仅显示并可编辑：研究主题（调整））</span>
+
+              <span class="ml-6 text-sm">筛选列：</span>
+              <select id="filter_target" class="border rounded px-2 py-1">
+                <option value="topic_orig">研究主题（原）</option>
+                <option value="field_orig">研究领域（原）</option>
+                <option value="topic_adj">研究主题（调整）</option>
+                <option value="field_adj">研究领域（调整）</option>
+              </select>
+              <select id="filter_value" class="border rounded px-2 py-1"></select>
+              <button id="btn_apply_filter" class="px-3 py-1 rounded bg-slate-700 text-white">应用筛选</button>
+              <button id="btn_clear_filter" class="px-3 py-1 rounded bg-slate-300">清除筛选</button>
+
+              <span class="ml-6 text-sm">目标类别：</span>
+              <select id="bulk_target" class="border rounded px-2 py-1"></select>
+              <button id="btn_bulk_selected" class="px-3 py-1 rounded bg-amber-600 text-white">将本页勾选 → 目标类别</button>
+              <button id="btn_bulk_filtered" class="px-3 py-1 rounded bg-amber-700 text-white">将当前筛选全部 → 目标类别</button>
+              <button id="btn_select_all" class="px-3 py-1 rounded bg-slate-200">全选本页</button>
+              <button id="btn_unselect_all" class="px-3 py-1 rounded bg-slate-200">取消全选</button>
+            </div>
+
+            <div class="flex flex-wrap items-center gap-3 text-sm">
+              <button id="btn_save_all" class="px-3 py-1 rounded bg-emerald-700 text-white">保存本页修改</button>
+              <label class="flex items-center gap-2">
+                <input type="checkbox" id="auto_save_enable">
+                <span>自动保存</span>
+              </label>
+              <span>间隔（分钟）</span>
+              <input id="auto_save_interval" type="number" min="1" value="5" class="border rounded px-2 py-1 w-20 text-center">
+              <span id="auto_save_msg" class="text-xs text-gray-500"></span>
+            </div>
+
+            <details class="bg-slate-50 border rounded p-3">
+              <summary class="cursor-pointer font-semibold">智能排序（议题内重排序 & 离群定位）</summary>
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mt-3">
+                <div>
+                  <label class="block text-sm text-gray-600 mb-1">分组依据</label>
+                  <select id="rank_group_by" class="border rounded px-2 py-1 w-full">
+                    <option value="topic_orig">研究主题（原）</option>
+                    <option value="topic_adj">研究主题（调整）</option>
+                  </select>
+                </div>
+                <div>
+                  <label class="block text-sm text-gray-600 mb-1">算法</label>
+                  <select id="rank_algo" class="border rounded px-2 py-1 w-full">
+                    <option value="centroid">Centroid（质心）</option>
+                    <option value="kmeans">K-Means</option>
+                    <option value="hdbscan">HDBSCAN（自动离群）</option>
+                  </select>
+                </div>
+                <div id="wrap_k">
+                  <label class="block text-sm text-gray-600 mb-1">K（K-Means 生效）</label>
+                  <input id="rank_k" type="number" value="3" min="1" class="border rounded px-2 py-1 w-full">
+                </div>
+                <div id="wrap_sigma">
+                  <label class="block text-sm text-gray-600 mb-1">离群阈值 σ</label>
+                  <input id="rank_sigma" type="number" step="0.1" value="2.0" class="border rounded px-2 py-1 w-full">
+                </div>
+                <div id="wrap_min_cluster">
+                  <label class="block text-sm text-gray-600 mb-1">最小簇大小（HDBSCAN）</label>
+                  <input id="rank_min_cluster" type="number" step="1" min="2" value="5" class="border rounded px-2 py-1 w-full">
+                </div>
+                <div>
+                  <label class="block text-sm text-gray-600 mb-1">嵌入来源</label>
+                  <select id="rank_emb_src" class="border rounded px-2 py-1 w-full">
+                    <option value="local">本地 sentence-transformers</option>
+                    <option value="openai">OpenAI Embeddings</option>
+                  </select>
+                </div>
+                <div>
+                  <label class="block text-sm text-gray-600 mb-1">排序方向</label>
+                  <select id="rank_order" class="border rounded px-2 py-1 w-full">
+                    <option value="asc">近的在前（分数小→大）</option>
+                    <option value="desc">远的在前（分数大→小）</option>
+                  </select>
+                </div>
+                <div class="flex items-center gap-2">
+                  <input id="rank_only_outliers" type="checkbox">
+                  <label for="rank_only_outliers" class="text-sm">仅看离群</label>
+                </div>
+                <div class="md:col-span-2 flex items-center gap-4">
+                  <label class="text-sm"><input id="rk_f_title" type="checkbox" checked> 标题</label>
+                  <label class="text-sm"><input id="rk_f_abstract" type="checkbox" checked> 摘要</label>
+                  <label class="text-sm"><input id="rk_f_summary" type="checkbox" checked> 结构化总结</label>
+                </div>
+                <div class="flex items-center gap-3">
+                  <button id="btn_do_ranking" class="px-4 py-2 rounded bg-slate-800 text-white">计算</button>
+                  <span id="rank_msg" class="text-sm text-gray-600"></span>
+                </div>
+              </div>
+            </details>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2 mb-3">
+            <span>分页：</span>
+            <button id="pg_first" class="px-2 py-1 rounded bg-slate-200">« 首</button>
+            <button id="pg_prev"  class="px-2 py-1 rounded bg-slate-200">‹ 前</button>
+            <input id="page_input" class="border rounded px-2 py-1 w-20 text-center" type="number" value="1" min="1">
+            <span>/</span>
+            <span id="page_total" class="w-12 text-center">1</span>
+            <button id="pg_next"  class="px-2 py-1 rounded bg-slate-200">后 ›</button>
+            <button id="pg_last"  class="px-2 py-1 rounded bg-slate-200">末 »</button>
+            <span class="ml-4">每页</span>
+            <input id="ps_input" class="border rounded px-2 py-1 w-20 text-center" type="number" value="50" min="1" max="5000">
+            <button id="btn_reload_page" class="px-3 py-1 rounded bg-slate-700 text-white">刷新</button>
+            <span class="text-sm text-gray-500 ml-2" id="page_info">—</span>
+          </div>
+
+          <div id="table_zone" class="bg-white rounded-2xl shadow overflow-x-auto"></div>
+
+        </section>
+
+        <section id="page-visual" class="page-section hidden space-y-8">
+          <div class="bg-white rounded-2xl shadow p-6 space-y-2">
+            <h2 class="text-lg font-semibold text-slate-900">数据可视化面板</h2>
+            <p class="text-sm text-slate-500">查看整体分布、筛选趋势以及排序结果的二维可视化。</p>
+          </div>
+
+          <div class="bg-white rounded-2xl shadow p-6">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="font-semibold">分类概览（点击类别即可筛选）</h3>
+              <div class="text-sm text-gray-500" id="total_msg">—</div>
+            </div>
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div>
+                <div class="flex items-center justify-between">
+                  <h4 class="text-sm font-semibold">研究主题（原）</h4>
+                  <button class="text-xs text-sky-700" id="btn_only_other_topic">只看『其他议题』</button>
+                </div>
+                <div id="chips_topic_orig" class="flex flex-wrap gap-2 my-2"></div>
+                <canvas id="chart_topic_orig" height="140"></canvas>
+              </div>
+              <div>
+                <div class="flex items-center justify-between">
+                  <h4 class="text-sm font-semibold">研究领域（原）</h4>
+                  <button class="text-xs text-sky-700" id="btn_only_other_field">只看『其他领域』</button>
+                </div>
+                <div id="chips_field_orig" class="flex flex-wrap gap-2 my-2"></div>
+                <canvas id="chart_field_orig" height="140"></canvas>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-white rounded-2xl shadow p-6">
+            <div class="flex flex-wrap items-center justify-between gap-3 mb-2">
+              <h3 class="font-semibold">排序可视化（2D 散点图）</h3>
+              <button id="btn_toggle_vis" class="px-3 py-1 rounded bg-slate-200 text-slate-700" aria-expanded="false">展开可视化</button>
+            </div>
+            <div id="rank_vis_body" class="space-y-3 hidden">
+              <div class="flex items-center justify-end">
+                <button id="btn_refresh_vis" class="px-3 py-1 rounded bg-slate-700 text-white">刷新可视化</button>
+              </div>
+              <div id="rank_vis_msg" class="text-sm text-gray-500">等待计算后展示。</div>
+              <div id="rank_vis_plot" class="w-full h-[460px]"></div>
+            </div>
+          </div>
+        </section>
+
+        <section id="page-settings" class="page-section hidden space-y-8">
+          <div class="bg-white rounded-2xl shadow p-6 space-y-3">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 class="text-lg font-semibold text-slate-900">OpenAI 兼容 API 设置</h2>
+                <p class="text-sm text-slate-500">配置 Base URL、密钥等参数，可同步保存到浏览器或服务器。</p>
+              </div>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label class="block text-sm text-gray-600 mb-1">Base URL</label>
+                <input id="cfg_base_url" class="w-full border rounded px-3 py-2" placeholder="https://api.openai.com">
+              </div>
+              <div>
+                <label class="block text-sm text-gray-600 mb-1">API Key</label>
+                <input id="cfg_api_key" class="w-full border rounded px-3 py-2" type="password" placeholder="sk-...">
+              </div>
+              <div>
+                <label class="block text-sm text-gray-600 mb-1">Model</label>
+                <input id="cfg_model" class="w-full border rounded px-3 py-2" placeholder="gpt-4o-mini">
+              </div>
+              <div>
+                <label class="block text-sm text-gray-600 mb-1">Temperature</label>
+                <input id="cfg_temp" class="w-full border rounded px-3 py-2" type="number" step="0.1" value="0.2">
+              </div>
+            </div>
+            <div class="flex flex-wrap gap-2 pt-2">
+              <button id="btn_save_cfg" class="px-4 py-2 rounded bg-slate-800 text-white">保存到浏览器</button>
+              <button id="btn_save_env" class="px-4 py-2 rounded bg-emerald-700 text-white">写入 .env（默认）</button>
+              <span id="cfg_msg" class="text-sm text-gray-600"></span>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
   </div>
-
-  <!-- 概览 -->
-  <div class="bg-white rounded-xl shadow p-4">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="font-semibold">分类概览（点击类别即可筛选）</h2>
-      <div class="text-sm text-gray-500" id="total_msg">—</div>
-    </div>
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <div>
-        <div class="flex items-center justify-between">
-          <h3 class="text-sm font-semibold">研究主题（原）</h3>
-          <button class="text-xs text-sky-700" id="btn_only_other_topic">只看『其他议题』</button>
-        </div>
-        <div id="chips_topic_orig" class="flex flex-wrap gap-2 my-2"></div>
-        <canvas id="chart_topic_orig" height="140"></canvas>
-      </div>
-      <div>
-        <div class="flex items-center justify-between">
-          <h3 class="text-sm font-semibold">研究领域（原）</h3>
-          <button class="text-xs text-sky-700" id="btn_only_other_field">只看『其他领域』</button>
-        </div>
-        <div id="chips_field_orig" class="flex flex-wrap gap-2 my-2"></div>
-        <canvas id="chart_field_orig" height="140"></canvas>
-      </div>
-    </div>
-  </div>
-
-  <!-- 工具条 -->
-  <div class="bg-white rounded-xl shadow p-4 space-y-3">
-    <div class="flex flex-wrap items-center gap-3">
-      <span class="text-sm">当前仅编辑：</span>
-      <select id="op_col_select" class="border rounded px-2 py-1">
-        <option value="topic">研究主题（调整）</option>
-        <option value="field">研究领域（调整）</option>
-      </select>
-      <span id="op_col_hint" class="text-xs text-gray-500">（仅显示并可编辑：研究主题（调整））</span>
-
-      <span class="ml-6 text-sm">筛选列：</span>
-      <select id="filter_target" class="border rounded px-2 py-1">
-        <option value="topic_orig">研究主题（原）</option>
-        <option value="field_orig">研究领域（原）</option>
-        <option value="topic_adj">研究主题（调整）</option>
-        <option value="field_adj">研究领域（调整）</option>
-      </select>
-      <select id="filter_value" class="border rounded px-2 py-1"></select>
-      <button id="btn_apply_filter" class="px-3 py-1 rounded bg-slate-700 text-white">应用筛选</button>
-      <button id="btn_clear_filter" class="px-3 py-1 rounded bg-slate-300">清除筛选</button>
-
-      <span class="ml-6 text-sm">目标类别：</span>
-      <select id="bulk_target" class="border rounded px-2 py-1"></select>
-      <button id="btn_bulk_selected" class="px-3 py-1 rounded bg-amber-600 text-white">将本页勾选 → 目标类别</button>
-      <button id="btn_bulk_filtered" class="px-3 py-1 rounded bg-amber-700 text-white">将当前筛选全部 → 目标类别</button>
-      <button id="btn_select_all" class="px-3 py-1 rounded bg-slate-200">全选本页</button>
-      <button id="btn_unselect_all" class="px-3 py-1 rounded bg-slate-200">取消全选</button>
-    </div>
-
-    <div class="flex flex-wrap items-center gap-3 text-sm">
-      <button id="btn_save_all" class="px-3 py-1 rounded bg-emerald-700 text-white">保存本页修改</button>
-      <label class="flex items-center gap-2">
-        <input type="checkbox" id="auto_save_enable">
-        <span>自动保存</span>
-      </label>
-      <span>间隔（分钟）</span>
-      <input id="auto_save_interval" type="number" min="1" value="5" class="border rounded px-2 py-1 w-20 text-center">
-      <span id="auto_save_msg" class="text-xs text-gray-500"></span>
-    </div>
-
-    <details class="bg-slate-50 border rounded p-3">
-      <summary class="cursor-pointer font-semibold">智能排序（议题内重排序 & 离群定位）</summary>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mt-3">
-        <div>
-          <label class="block text-sm text-gray-600 mb-1">分组依据</label>
-          <select id="rank_group_by" class="border rounded px-2 py-1 w-full">
-            <option value="topic_orig">研究主题（原）</option>
-            <option value="topic_adj">研究主题（调整）</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm text-gray-600 mb-1">算法</label>
-          <select id="rank_algo" class="border rounded px-2 py-1 w-full">
-            <option value="centroid">Centroid（质心）</option>
-            <option value="kmeans">K-Means</option>
-            <option value="hdbscan">HDBSCAN（自动离群）</option>
-          </select>
-        </div>
-        <div id="wrap_k">
-          <label class="block text-sm text-gray-600 mb-1">K（K-Means 生效）</label>
-          <input id="rank_k" type="number" value="3" min="1" class="border rounded px-2 py-1 w-full">
-        </div>
-        <div id="wrap_sigma">
-          <label class="block text-sm text-gray-600 mb-1">离群阈值 σ</label>
-          <input id="rank_sigma" type="number" step="0.1" value="2.0" class="border rounded px-2 py-1 w-full">
-        </div>
-        <div id="wrap_min_cluster">
-          <label class="block text-sm text-gray-600 mb-1">最小簇大小（HDBSCAN）</label>
-          <input id="rank_min_cluster" type="number" step="1" min="2" value="5" class="border rounded px-2 py-1 w-full">
-        </div>
-        <div>
-          <label class="block text-sm text-gray-600 mb-1">嵌入来源</label>
-          <select id="rank_emb_src" class="border rounded px-2 py-1 w-full">
-            <option value="local">本地 sentence-transformers</option>
-            <option value="openai">OpenAI Embeddings</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm text-gray-600 mb-1">排序方向</label>
-          <select id="rank_order" class="border rounded px-2 py-1 w-full">
-            <option value="asc">近的在前（分数小→大）</option>
-            <option value="desc">远的在前（分数大→小）</option>
-          </select>
-        </div>
-        <div class="flex items-center gap-2">
-          <input id="rank_only_outliers" type="checkbox">
-          <label for="rank_only_outliers" class="text-sm">仅看离群</label>
-        </div>
-        <div class="md:col-span-2 flex items-center gap-4">
-          <label class="text-sm"><input id="rk_f_title" type="checkbox" checked> 标题</label>
-          <label class="text-sm"><input id="rk_f_abstract" type="checkbox" checked> 摘要</label>
-          <label class="text-sm"><input id="rk_f_summary" type="checkbox" checked> 结构化总结</label>
-        </div>
-        <div class="flex items-center gap-3">
-          <button id="btn_do_ranking" class="px-4 py-2 rounded bg-slate-800 text-white">计算</button>
-          <span id="rank_msg" class="text-sm text-gray-600"></span>
-        </div>
-      </div>
-    </details>
-  </div>
-
-  <div class="bg-white rounded-xl shadow p-4">
-    <div class="flex flex-wrap items-center justify-between gap-3 mb-2">
-      <h2 class="font-semibold">排序可视化（2D 散点图）</h2>
-      <button id="btn_toggle_vis" class="px-3 py-1 rounded bg-slate-200 text-slate-700" aria-expanded="false">展开可视化</button>
-    </div>
-    <div id="rank_vis_body" class="space-y-3 hidden">
-      <div class="flex items-center justify-end">
-        <button id="btn_refresh_vis" class="px-3 py-1 rounded bg-slate-700 text-white">刷新可视化</button>
-      </div>
-      <div id="rank_vis_msg" class="text-sm text-gray-500">等待计算后展示。</div>
-      <div id="rank_vis_plot" class="w-full h-[460px]"></div>
-    </div>
-  </div>
-
-  <!-- 分页条 -->
-  <div class="flex flex-wrap items-center gap-2 mb-3">
-    <span>分页：</span>
-    <button id="pg_first" class="px-2 py-1 rounded bg-slate-200">« 首</button>
-    <button id="pg_prev"  class="px-2 py-1 rounded bg-slate-200">‹ 前</button>
-    <input id="page_input" class="border rounded px-2 py-1 w-20 text-center" type="number" value="1" min="1">
-    <span>/</span>
-    <span id="page_total" class="w-12 text-center">1</span>
-    <button id="pg_next"  class="px-2 py-1 rounded bg-slate-200">后 ›</button>
-    <button id="pg_last"  class="px-2 py-1 rounded bg-slate-200">末 »</button>
-    <span class="ml-4">每页</span>
-    <input id="ps_input" class="border rounded px-2 py-1 w-20 text-center" type="number" value="50" min="1" max="5000">
-    <button id="btn_reload_page" class="px-3 py-1 rounded bg-slate-700 text-white">刷新</button>
-    <span class="text-sm text-gray-500 ml-2" id="page_info">—</span>
-  </div>
-
-  <!-- 数据表 -->
-  <div id="table_zone" class="bg-white rounded-xl shadow overflow-x-auto"></div>
-
-  <!-- OpenAI 设置 -->
-  <details class="bg-white rounded-xl shadow p-4">
-    <summary class="cursor-pointer font-semibold">OpenAI 兼容 API 设置（折叠）</summary>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
-      <div><label class="block text-sm text-gray-600 mb-1">Base URL</label><input id="cfg_base_url" class="w-full border rounded px-3 py-2" placeholder="https://api.openai.com"></div>
-      <div><label class="block text-sm text-gray-600 mb-1">API Key</label><input id="cfg_api_key" class="w-full border rounded px-3 py-2" type="password" placeholder="sk-..."></div>
-      <div><label class="block text-sm text-gray-600 mb-1">Model</label><input id="cfg_model" class="w-full border rounded px-3 py-2" placeholder="gpt-4o-mini"></div>
-      <div><label class="block text-sm text-gray-600 mb-1">Temperature</label><input id="cfg_temp" class="w-full border rounded px-3 py-2" type="number" step="0.1" value="0.2"></div>
-    </div>
-    <div class="mt-3 flex flex-wrap gap-2">
-      <button id="btn_save_cfg" class="px-4 py-2 rounded bg-slate-800 text-white">保存到浏览器</button>
-      <button id="btn_save_env" class="px-4 py-2 rounded bg-emerald-700 text-white">写入 .env（默认）</button>
-      <span id="cfg_msg" class="text-sm text-gray-600"></span>
-    </div>
-  </details>
 </div>
-
-<!-- 会话列表弹窗 -->
 <dialog id="dlg_sessions" class="rounded-xl p-0 w-[680px] max-w-[95vw]">
   <div class="p-4 border-b flex items-center justify-between">
     <h3 class="font-semibold">载入会话</h3>
@@ -254,7 +328,6 @@
     <button class="px-3 py-2 rounded bg-slate-700 text-white" onclick="qs('dlg_sessions').close()">关闭</button>
   </div>
 </dialog>
-
 <script>
 /* ===================== 全局状态 ===================== */
 let TOPIC_LIST=[], FIELD_LIST=[], ADJ_TOPIC_COL="", ADJ_FIELD_COL="";
@@ -273,6 +346,58 @@ const qs = id=>document.getElementById(id);
 const escapeHtml = s=>String(s).replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
 const escapeAttr = s=>escapeHtml(s).replaceAll('"','&quot;');
 const setBadge = ()=>{ qs('session_badge').textContent = "Session: " + (SESSION_ID||"—"); };
+
+const SIDEBAR = document.getElementById('sidebar');
+const SIDEBAR_TOGGLE = document.getElementById('sidebar_toggle');
+let SIDEBAR_COLLAPSED = false;
+
+function applySidebarState(collapsed){
+  if(!SIDEBAR) return;
+  SIDEBAR_COLLAPSED = collapsed;
+  SIDEBAR.dataset.collapsed = collapsed ? 'true' : 'false';
+  if(SIDEBAR_TOGGLE){
+    SIDEBAR_TOGGLE.setAttribute('aria-expanded', (!collapsed).toString());
+    SIDEBAR_TOGGLE.title = collapsed ? '展开侧边栏' : '收起侧边栏';
+    SIDEBAR_TOGGLE.setAttribute('aria-label', SIDEBAR_TOGGLE.title);
+    const icon = SIDEBAR_TOGGLE.querySelector('iconify-icon');
+    if(icon){
+      icon.setAttribute('icon', collapsed ? 'heroicons-outline:chevron-right' : 'heroicons-outline:chevron-left');
+    }
+  }
+  try{ localStorage.setItem('sidebar_collapsed', collapsed ? '1' : '0'); }catch(e){}
+}
+
+if(SIDEBAR_TOGGLE){
+  SIDEBAR_TOGGLE.addEventListener('click', ()=>{
+    applySidebarState(!SIDEBAR_COLLAPSED);
+  });
+}
+
+try{
+  const storedState = localStorage.getItem('sidebar_collapsed');
+  applySidebarState(storedState === '1');
+}catch(e){
+  applySidebarState(false);
+}
+
+const PAGE_SECTIONS = Array.from(document.querySelectorAll('.page-section'));
+const NAV_BUTTONS = Array.from(document.querySelectorAll('.nav-link[data-target]'));
+const MOBILE_PAGE_SELECT = document.getElementById('mobile_page_select');
+
+function activatePage(targetId){
+  PAGE_SECTIONS.forEach(section=>section.classList.toggle('hidden', section.id !== targetId));
+  NAV_BUTTONS.forEach(btn=>btn.classList.toggle('nav-link-active', btn.dataset.target === targetId));
+  if(MOBILE_PAGE_SELECT && MOBILE_PAGE_SELECT.value !== targetId){
+    MOBILE_PAGE_SELECT.value = targetId;
+  }
+}
+
+NAV_BUTTONS.forEach(btn=>btn.addEventListener('click', ()=>activatePage(btn.dataset.target)));
+if(MOBILE_PAGE_SELECT){
+  MOBILE_PAGE_SELECT.addEventListener('change', e=>activatePage(e.target.value));
+}
+
+activatePage('page-coding');
 
 /* ---- 默认兜底表 ---- */
 const DEF_TOPICS = ["健康议题","经济议题","政治议题","环境议题","传播模式与行为","媒介制度与平台治理","科技议题","文化议题","宗教议题","其他议题"];

--- a/static/style.css
+++ b/static/style.css
@@ -15,3 +15,30 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 .file-input{ display:block; width:100%; border:1px solid rgba(148,163,184,0.6); border-radius:0.75rem; padding:0.65rem 0.75rem; font-size:0.875rem; color:#0f172a; background:white; transition:border-color .15s ease, box-shadow .15s ease; }
 .file-input:hover{ border-color:#2563eb; }
 .file-input:focus{ outline:none; border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.12); }
+
+
+.nav-link{display:flex;align-items:center;gap:0.75rem;width:100%;padding:0.75rem 1rem;border-radius:0.9rem;font-weight:600;color:#475569;background:transparent;transition:background-color .15s ease,color .15s ease,transform .15s ease,box-shadow .15s ease;}
+.nav-link iconify-icon{width:1.25rem;height:1.25rem;color:inherit;}
+.nav-link:hover{color:#0f172a;background-color:rgba(148,163,184,0.16);transform:translateX(2px);}
+.nav-link-active{color:#fff;background:linear-gradient(135deg,#1e293b 0%,#0f172a 100%);box-shadow:0 18px 35px -25px rgba(15,23,42,0.8);transform:none;}
+.nav-link-active:hover{color:#fff;}
+
+#sidebar{width:16rem;overflow:hidden;}
+#sidebar .nav-label{display:inline-flex;white-space:nowrap;}
+#sidebar .nav-section-label{display:block;}
+#sidebar .sidebar-footer{display:flex;flex-direction:column;gap:0.5rem;}
+#sidebar .sidebar-toggle{display:inline-flex;align-items:center;justify-content:center;width:2.5rem;height:2.5rem;border-radius:9999px;background-color:rgba(148,163,184,0.18);color:#1e293b;transition:background-color .2s ease,transform .2s ease;}
+#sidebar .sidebar-toggle:hover{background-color:rgba(148,163,184,0.32);transform:translateX(1px);}
+#sidebar[data-collapsed="true"]{width:5.25rem;}
+#sidebar[data-collapsed="true"] nav{align-items:center;}
+#sidebar[data-collapsed="true"] .sidebar-footer{justify-content:center;padding-left:0.75rem;padding-right:0.75rem;}
+#sidebar[data-collapsed="true"] .nav-label,
+#sidebar[data-collapsed="true"] .nav-section-label{display:none;}
+#sidebar[data-collapsed="true"] .nav-link{justify-content:center;padding:0.75rem;}
+#sidebar[data-collapsed="true"] .nav-link iconify-icon{margin:0;}
+#sidebar[data-collapsed="true"]:hover{width:16rem;}
+#sidebar[data-collapsed="true"]:hover nav{align-items:stretch;}
+#sidebar[data-collapsed="true"]:hover .sidebar-footer{justify-content:flex-start;padding-left:0.5rem;padding-right:0.5rem;}
+#sidebar[data-collapsed="true"]:hover .nav-label{display:inline-flex;}
+#sidebar[data-collapsed="true"]:hover .nav-section-label{display:block;}
+#sidebar[data-collapsed="true"]:hover .nav-link{justify-content:flex-start;padding:0.75rem 1rem;}


### PR DESCRIPTION
## Summary
- keep the responsive application shell with sidebar and top bar, now with a collapsible icon-only mode that stores state and hover expands
- separate the coding workspace, visualization dashboard, and new OpenAI settings section with navigation state handling including mobile select
- relocate the OpenAI API configuration into its own settings page and update sidebar styling for the bottom-left entry point

## Testing
- not run (frontend-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e29ec6f1588327bcd43f456d40b5c9