### PR TITLE
Fix sidebar toggle behavior and unify button styling

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -46,7 +46,7 @@
       <div class="flex flex-col w-full h-full">
         <div class="px-4 pt-6 pb-4 flex items-center justify-between">
           <p class="nav-section-label text-xs font-semibold text-slate-400 uppercase tracking-wide">导航</p>
-          <button id="sidebar_toggle" class="sidebar-toggle" type="button" aria-expanded="true" aria-label="收起侧边栏" title="收起侧边栏">
+          <button id="sidebar_toggle" class="sidebar-toggle btn btn-ghost" type="button" aria-expanded="true" aria-label="收起侧边栏" title="收起侧边栏">
             <iconify-icon icon="heroicons-outline:chevron-left" class="w-5 h-5"></iconify-icon>
           </button>
         </div>
@@ -133,19 +133,19 @@
                 <option value="field_adj">研究领域（调整）</option>
               </select>
               <select id="filter_value" class="border rounded px-2 py-1"></select>
-              <button id="btn_apply_filter" class="px-3 py-1 rounded bg-slate-700 text-white">应用筛选</button>
-              <button id="btn_clear_filter" class="px-3 py-1 rounded bg-slate-300">清除筛选</button>
+              <button id="btn_apply_filter" class="btn btn-sm bg-slate-700 text-white hover:bg-slate-600">应用筛选</button>
+              <button id="btn_clear_filter" class="btn btn-sm bg-slate-200 text-slate-700 hover:bg-slate-300">清除筛选</button>
 
               <span class="ml-6 text-sm">目标类别：</span>
               <select id="bulk_target" class="border rounded px-2 py-1"></select>
-              <button id="btn_bulk_selected" class="px-3 py-1 rounded bg-amber-600 text-white">将本页勾选 → 目标类别</button>
-              <button id="btn_bulk_filtered" class="px-3 py-1 rounded bg-amber-700 text-white">将当前筛选全部 → 目标类别</button>
-              <button id="btn_select_all" class="px-3 py-1 rounded bg-slate-200">全选本页</button>
-              <button id="btn_unselect_all" class="px-3 py-1 rounded bg-slate-200">取消全选</button>
+              <button id="btn_bulk_selected" class="btn btn-sm bg-amber-600 text-white hover:bg-amber-500">将本页勾选 → 目标类别</button>
+              <button id="btn_bulk_filtered" class="btn btn-sm bg-amber-700 text-white hover:bg-amber-600">将当前筛选全部 → 目标类别</button>
+              <button id="btn_select_all" class="btn btn-sm bg-slate-200 text-slate-700 hover:bg-slate-300">全选本页</button>
+              <button id="btn_unselect_all" class="btn btn-sm bg-slate-200 text-slate-700 hover:bg-slate-300">取消全选</button>
             </div>
 
             <div class="flex flex-wrap items-center gap-3 text-sm">
-              <button id="btn_save_all" class="px-3 py-1 rounded bg-emerald-700 text-white">保存本页修改</button>
+              <button id="btn_save_all" class="btn btn-sm bg-emerald-700 text-white hover:bg-emerald-600">保存本页修改</button>
               <label class="flex items-center gap-2">
                 <input type="checkbox" id="auto_save_enable">
                 <span>自动保存</span>
@@ -227,7 +227,7 @@
             <button id="pg_last"  class="px-2 py-1 rounded bg-slate-200">末 »</button>
             <span class="ml-4">每页</span>
             <input id="ps_input" class="border rounded px-2 py-1 w-20 text-center" type="number" value="50" min="1" max="5000">
-            <button id="btn_reload_page" class="px-3 py-1 rounded bg-slate-700 text-white">刷新</button>
+            <button id="btn_reload_page" class="btn btn-sm bg-slate-700 text-white hover:bg-slate-600">刷新</button>
             <span class="text-sm text-gray-500 ml-2" id="page_info">—</span>
           </div>
 
@@ -269,11 +269,11 @@
           <div class="bg-white rounded-2xl shadow p-6">
             <div class="flex flex-wrap items-center justify-between gap-3 mb-2">
               <h3 class="font-semibold">排序可视化（2D 散点图）</h3>
-              <button id="btn_toggle_vis" class="px-3 py-1 rounded bg-slate-200 text-slate-700" aria-expanded="false">展开可视化</button>
+              <button id="btn_toggle_vis" class="btn btn-sm bg-slate-200 text-slate-700 hover:bg-slate-300" aria-expanded="false">展开可视化</button>
             </div>
             <div id="rank_vis_body" class="space-y-3 hidden">
               <div class="flex items-center justify-end">
-                <button id="btn_refresh_vis" class="px-3 py-1 rounded bg-slate-700 text-white">刷新可视化</button>
+                <button id="btn_refresh_vis" class="btn btn-sm bg-slate-700 text-white hover:bg-slate-600">刷新可视化</button>
               </div>
               <div id="rank_vis_msg" class="text-sm text-gray-500">等待计算后展示。</div>
               <div id="rank_vis_plot" class="w-full h-[460px]"></div>
@@ -321,11 +321,11 @@
 <dialog id="dlg_sessions" class="rounded-xl p-0 w-[680px] max-w-[95vw]">
   <div class="p-4 border-b flex items-center justify-between">
     <h3 class="font-semibold">载入会话</h3>
-    <button onclick="qs('dlg_sessions').close()" class="text-slate-600">✕</button>
+    <button onclick="qs('dlg_sessions').close()" class="btn btn-sm btn-ghost text-slate-600">✕</button>
   </div>
   <div id="sess_list_zone" class="p-4 max-h-[60vh] overflow-y-auto text-sm"></div>
   <div class="p-4 border-t flex items-center justify-end">
-    <button class="px-3 py-2 rounded bg-slate-700 text-white" onclick="qs('dlg_sessions').close()">关闭</button>
+    <button class="btn bg-slate-700 text-white hover:bg-slate-600" onclick="qs('dlg_sessions').close()">关闭</button>
   </div>
 </dialog>
 <script>
@@ -687,8 +687,8 @@ function renderTable(rows){
       <td class="px-3 py-2">${escapeHtml(String(r["DOI"]||""))}</td>
       <td class="px-3 py-2">${(r["智能排序分数"]!==undefined && r["智能排序分数"]!=="")? Number(r["智能排序分数"]).toFixed(4): ""}</td>
       <td class="px-3 py-2"><div class="flex flex-col gap-2">
-        <button class="px-3 py-1 rounded bg-emerald-600 text-white" onclick="saveRow(${idx}, this)">保存</button>
-        <button class="px-3 py-1 rounded bg-sky-600 text-white" onclick="suggestRow(${idx}, this)">智能建议</button>
+        <button class="btn btn-sm bg-emerald-600 text-white hover:bg-emerald-500" onclick="saveRow(${idx}, this)">保存</button>
+        <button class="btn btn-sm bg-sky-600 text-white hover:bg-sky-500" onclick="suggestRow(${idx}, this)">智能建议</button>
       </div></td></tr>`;
   });
   html += `</tbody></table>`; qs('table_zone').innerHTML=html;

--- a/static/style.css
+++ b/static/style.css
@@ -4,11 +4,22 @@
 .chip{ padding:2px 8px; border-radius:9999px; background:#f1f5f9; }
 .chip:hover{ background:#e2e8f0; }
 dialog::backdrop { background: rgba(0,0,0,.25); }
-.action-btn{ display:inline-flex; align-items:center; gap:0.5rem; border-radius:0.75rem; padding:0.6rem 1rem; font-size:0.875rem; font-weight:600; transition:transform .15s ease, box-shadow .15s ease, background-color .15s ease; }
-.action-btn:hover{ transform:translateY(-1px); box-shadow:0 10px 25px -15px rgba(15,23,42,0.65); }
+.btn,
+.action-btn{ display:inline-flex; align-items:center; justify-content:center; gap:0.5rem; min-height:2.5rem; padding:0.45rem 0.95rem; border-radius:0.85rem; font-size:0.875rem; font-weight:600; line-height:1.25rem; border:1px solid transparent; transition:transform .15s ease, box-shadow .15s ease, background-color .15s ease, border-color .15s ease; }
+.btn:hover{ transform:translateY(-1px); box-shadow:0 10px 20px -18px rgba(15,23,42,0.45); }
+.btn iconify-icon,
+.action-btn iconify-icon{ width:1.25rem; height:1.25rem; color:inherit; flex-shrink:0; display:block; }
+.btn:focus-visible,
 .action-btn:focus-visible{ outline:2px solid rgba(14,116,144,0.6); outline-offset:2px; }
+.btn:disabled,
 .action-btn:disabled{ opacity:0.6; cursor:not-allowed; transform:none; box-shadow:none; }
-.action-btn iconify-icon{ width:20px; height:20px; color:currentColor; display:block; flex-shrink:0; }
+.btn-sm{ min-height:2.25rem; padding:0.35rem 0.75rem; font-size:0.8125rem; }
+.btn-ghost{ background-color:rgba(148,163,184,0.18); color:#1e293b; }
+.btn-ghost:hover{ background-color:rgba(148,163,184,0.3); }
+.btn-ghost:focus-visible{ outline-color:rgba(148,163,184,0.55); }
+.btn-ghost{ border-color:transparent; }
+.action-btn{ gap:0.55rem; padding:0.6rem 1.05rem; min-height:2.65rem; }
+.action-btn:hover{ transform:translateY(-1px); box-shadow:0 10px 25px -18px rgba(15,23,42,0.65); }
 .sess-table-actions{ min-width:110px; }
 .sess-table-actions button{ display:inline-flex; align-items:center; justify-content:center; width:100%; white-space:nowrap; }
 .info-card{ background:linear-gradient(135deg,#f8fafc 0%,#f1f5f9 40%,#e2e8f0 100%); border:1px solid rgba(148,163,184,0.35); }
@@ -30,15 +41,12 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 #sidebar .sidebar-toggle{display:inline-flex;align-items:center;justify-content:center;width:2.5rem;height:2.5rem;border-radius:9999px;background-color:rgba(148,163,184,0.18);color:#1e293b;transition:background-color .2s ease,transform .2s ease;}
 #sidebar .sidebar-toggle:hover{background-color:rgba(148,163,184,0.32);transform:translateX(1px);}
 #sidebar[data-collapsed="true"]{width:5.25rem;}
-#sidebar[data-collapsed="true"] nav{align-items:center;}
-#sidebar[data-collapsed="true"] .sidebar-footer{justify-content:center;padding-left:0.75rem;padding-right:0.75rem;}
+#sidebar[data-collapsed="true"] nav{align-items:center;padding-left:0.5rem;padding-right:0.5rem;}
+#sidebar[data-collapsed="true"] > div{padding-left:1rem;padding-right:1rem;}
+#sidebar[data-collapsed="true"] .sidebar-footer{justify-content:center;padding-left:0.5rem;padding-right:0.5rem;}
+#sidebar[data-collapsed="true"] .sidebar-toggle{margin-left:auto;margin-right:auto;}
 #sidebar[data-collapsed="true"] .nav-label,
 #sidebar[data-collapsed="true"] .nav-section-label{display:none;}
 #sidebar[data-collapsed="true"] .nav-link{justify-content:center;padding:0.75rem;}
 #sidebar[data-collapsed="true"] .nav-link iconify-icon{margin:0;}
-#sidebar[data-collapsed="true"]:hover{width:16rem;}
-#sidebar[data-collapsed="true"]:hover nav{align-items:stretch;}
-#sidebar[data-collapsed="true"]:hover .sidebar-footer{justify-content:flex-start;padding-left:0.5rem;padding-right:0.5rem;}
-#sidebar[data-collapsed="true"]:hover .nav-label{display:inline-flex;}
-#sidebar[data-collapsed="true"]:hover .nav-section-label{display:block;}
-#sidebar[data-collapsed="true"]:hover .nav-link{justify-content:flex-start;padding:0.75rem 1rem;}
+#sidebar{transition:width .25s ease;}


### PR DESCRIPTION
## Summary
- remove hover-triggered expansion from the sidebar and tidy collapsed spacing so the toggle works consistently
- add a shared button style with small variant and apply it to toolbar, dialog, and table actions for consistent sizing
- refresh icon sizing and hover feedback for buttons while keeping existing color cues

## Testing
- manual visual inspection

------
https://chatgpt.com/codex/tasks/task_e_68e2a32dc7b8832784d91239534b0206