### PR TITLE
Adjust sidebar collapse animation

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -57,17 +57,17 @@
         </div>
         <nav class="flex-1 flex flex-col gap-2 px-2">
           <button class="nav-link nav-link-active" data-target="page-coding" title="编码工作台" aria-label="编码工作台">
-            <iconify-icon icon="heroicons-outline:adjustments-horizontal" class="text-lg"></iconify-icon>
+            <iconify-icon icon="heroicons-outline:adjustments-horizontal" class="nav-icon w-5 h-5"></iconify-icon>
             <span class="nav-label">编码工作台</span>
           </button>
           <button class="nav-link" data-target="page-visual" title="数据可视化" aria-label="数据可视化">
-            <iconify-icon icon="heroicons-outline:chart-pie" class="text-lg"></iconify-icon>
+            <iconify-icon icon="heroicons-outline:chart-pie" class="nav-icon w-5 h-5"></iconify-icon>
             <span class="nav-label">数据可视化</span>
           </button>
         </nav>
         <div class="sidebar-footer px-2 pt-4 pb-6 border-t border-slate-200">
           <button class="nav-link" data-target="page-settings" title="OpenAI API 设置" aria-label="OpenAI API 设置">
-            <iconify-icon icon="heroicons-outline:cog-6-tooth" class="text-lg"></iconify-icon>
+            <iconify-icon icon="heroicons-outline:cog-6-tooth" class="nav-icon w-5 h-5"></iconify-icon>
             <span class="nav-label">OpenAI API 设置</span>
           </button>
         </div>
@@ -398,9 +398,26 @@ async function refreshSessionMeta(){
   }
 }
 
+const PAGE_HEADER = document.querySelector('header');
 const SIDEBAR = document.getElementById('sidebar');
 const SIDEBAR_TOGGLE = document.getElementById('sidebar_toggle');
 let SIDEBAR_COLLAPSED = false;
+
+function updateSidebarOffset(){
+  if(!PAGE_HEADER){ return; }
+  const rect = PAGE_HEADER.getBoundingClientRect();
+  let offset = (window.scrollY <= 0) ? PAGE_HEADER.offsetHeight : rect.bottom;
+  if(!Number.isFinite(offset)){ offset = PAGE_HEADER.offsetHeight || 0; }
+  offset = Math.max(0, Math.min(offset, window.innerHeight || offset));
+  document.documentElement.style.setProperty('--header-offset', `${offset}px`);
+}
+
+if(PAGE_HEADER){
+  window.addEventListener('scroll', updateSidebarOffset, {passive:true});
+  window.addEventListener('resize', updateSidebarOffset);
+  window.addEventListener('load', updateSidebarOffset);
+  requestAnimationFrame(updateSidebarOffset);
+}
 
 function applySidebarState(collapsed){
   if(!SIDEBAR) return;

--- a/static/style.css
+++ b/static/style.css
@@ -3,6 +3,7 @@
 .cell-outlier    { background-color:#FFDAD6; } /* 淡红：离群 */
 .chip{ padding:2px 8px; border-radius:9999px; background:#f1f5f9; }
 .chip:hover{ background:#e2e8f0; }
+:root{ --header-offset:0px; }
 dialog::backdrop { background: rgba(0,0,0,.25); }
 .btn,
 .action-btn{ display:inline-flex; align-items:center; justify-content:center; gap:0.5rem; min-height:2.5rem; padding:0.45rem 0.95rem; border-radius:0.85rem; font-size:0.875rem; font-weight:600; line-height:1.25rem; border:1px solid transparent; transition:transform .15s ease, box-shadow .15s ease, background-color .15s ease, border-color .15s ease; }
@@ -28,26 +29,25 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 .file-input:focus{ outline:none; border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.12); }
 
 
-.nav-link{display:flex;align-items:center;gap:0.75rem;width:100%;padding:0.75rem 1rem;border-radius:0.9rem;font-weight:600;color:#475569;background:transparent;transition:background-color .15s ease,color .15s ease,transform .15s ease,box-shadow .15s ease;}
-.nav-link iconify-icon{width:1.35rem;height:1.35rem;color:inherit;}
+.nav-link{display:flex;align-items:center;gap:0.75rem;width:100%;padding:0.75rem 1rem;border-radius:0.9rem;font-weight:600;color:#475569;background:transparent;transition:background-color .15s ease,color .15s ease,transform .15s ease,box-shadow .15s ease;overflow:hidden;}
+.nav-link iconify-icon{width:1.25rem;height:1.25rem;color:inherit;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;margin:0;}
 .nav-link:hover{color:#0f172a;background-color:rgba(148,163,184,0.16);transform:translateX(2px);}
 .nav-link-active{color:#fff;background:linear-gradient(135deg,#1e293b 0%,#0f172a 100%);box-shadow:0 18px 35px -25px rgba(15,23,42,0.8);transform:none;}
 .nav-link-active:hover{color:#fff;}
 
-#sidebar{width:16rem;overflow:hidden;position:sticky;top:0;height:100vh;max-height:100vh;}
+#sidebar{width:16rem;overflow:hidden;position:sticky;top:var(--header-offset,0px);height:calc(100vh - var(--header-offset,0px));max-height:calc(100vh - var(--header-offset,0px));transition:width .25s ease,top .2s ease,height .2s ease;overflow-y:auto;}
 #sidebar>div{height:100%;}
-#sidebar .nav-label{display:inline-flex;white-space:nowrap;}
-#sidebar .nav-section-label{display:block;}
+#sidebar .nav-label{display:inline-flex;align-items:center;white-space:nowrap;max-width:100%;opacity:1;transform:translateX(0);transition:opacity .2s ease,transform .2s ease,max-width .2s ease;overflow:hidden;}
+#sidebar .nav-section-label{display:block;opacity:1;transform:translateY(0);transition:opacity .2s ease,transform .2s ease,max-height .2s ease;max-height:2.5rem;overflow:hidden;}
 #sidebar .sidebar-footer{display:flex;flex-direction:column;gap:0.5rem;}
 #sidebar .sidebar-toggle{display:inline-flex;align-items:center;justify-content:center;width:2.5rem;height:2.5rem;border-radius:9999px;background-color:rgba(148,163,184,0.18);color:#1e293b;transition:background-color .2s ease,transform .2s ease;}
 #sidebar .sidebar-toggle:hover{background-color:rgba(148,163,184,0.32);transform:translateX(1px);}
-#sidebar[data-collapsed="true"]{width:5.25rem;}
+#sidebar[data-collapsed="true"]{width:5.25rem;transition:none;}
 #sidebar[data-collapsed="true"] > div{align-items:center;justify-content:center;padding-left:1rem;padding-right:1rem;}
 #sidebar[data-collapsed="true"] nav{align-items:center;justify-content:center;padding-left:0;padding-right:0;}
 #sidebar[data-collapsed="true"] .sidebar-footer{justify-content:center;padding-left:0;padding-right:0;padding-top:1.5rem;}
 #sidebar[data-collapsed="true"] .sidebar-toggle{margin-left:auto;margin-right:auto;margin-bottom:1.5rem;}
-#sidebar[data-collapsed="true"] .nav-label,
-#sidebar[data-collapsed="true"] .nav-section-label{display:none;}
-#sidebar[data-collapsed="true"] .nav-link{justify-content:center;padding:0.9rem;}
+#sidebar[data-collapsed="true"] .nav-label{max-width:0;opacity:0;transform:translateX(-0.5rem);transition:none;}
+#sidebar[data-collapsed="true"] .nav-section-label{max-height:0;opacity:0;transform:translateY(-0.5rem);margin:0;transition:none;}
+#sidebar[data-collapsed="true"] .nav-link{justify-content:center;padding:0.9rem;gap:0;}
 #sidebar[data-collapsed="true"] .nav-link iconify-icon{margin:0;width:1.6rem;height:1.6rem;}
-#sidebar{transition:width .25s ease;overflow-y:auto;}


### PR DESCRIPTION
## Summary
- adjust the sidebar layout to respect the header height and animate label visibility when collapsing
- center and resize sidebar navigation icons using consistent Heroicons sizing classes
- add a script that keeps the sidebar offset in sync with the header height on scroll and resize
- disable the collapse animation so the sidebar closes instantly while keeping the expand animation

## Testing
- Not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e2b455c0688327990bcad4027f1277