### PR TITLE
Bundle heroicons locally and adjust sidebar animation

### DIFF
--- a/static/heroicons.js
+++ b/static/heroicons.js
@@ -1,0 +1,119 @@
+(function(){
+  // Heroicons outline icons bundled locally to avoid external network requests.
+  // Icons are sourced from https://github.com/tailwindlabs/heroicons (MIT License).
+  const NS = 'http://www.w3.org/2000/svg';
+  const defaultViewBox = '0 0 24 24';
+  const defaultStrokeWidth = 1.5;
+  const defaultPathAttrs = { 'stroke-linecap': 'round', 'stroke-linejoin': 'round' };
+
+  const icons = {
+    'clipboard-document-list': {
+      paths: [
+        "M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"
+      ]
+    },
+    'chevron-left': {
+      paths: [
+        "M15.75 19.5 8.25 12l7.5-7.5"
+      ]
+    },
+    'chevron-right': {
+      paths: [
+        "m8.25 4.5 7.5 7.5-7.5 7.5"
+      ]
+    },
+    'adjustments-horizontal': {
+      paths: [
+        "M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"
+      ]
+    },
+    'chart-pie': {
+      paths: [
+        "M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z",
+        "M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"
+      ]
+    },
+    'cog-6-tooth': {
+      paths: [
+        "M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z",
+        "M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+      ]
+    },
+    'arrow-up-tray': {
+      paths: [
+        "M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+      ]
+    },
+    'cloud-arrow-up': {
+      paths: [
+        "M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z"
+      ]
+    },
+    'folder-arrow-down': {
+      paths: [
+        "m9 13.5 3 3m0 0 3-3m-3 3v-6m1.06-4.19-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
+      ]
+    },
+    'document-arrow-down': {
+      paths: [
+        "M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+      ]
+    },
+    'arrow-down-tray': {
+      paths: [
+        "M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+      ]
+    }
+  };
+
+  function applyIcon(el, name){
+    if(!el) return;
+    const icon = icons[name];
+    if(!icon) return;
+    while(el.firstChild){ el.removeChild(el.firstChild); }
+    const viewBox = icon.viewBox || defaultViewBox;
+    el.setAttribute('viewBox', viewBox);
+    el.setAttribute('fill', 'none');
+    el.setAttribute('stroke', 'currentColor');
+    el.setAttribute('stroke-width', icon.strokeWidth || defaultStrokeWidth);
+    if(!el.hasAttribute('aria-hidden')){
+      el.setAttribute('aria-hidden', 'true');
+    }
+    const paths = Array.isArray(icon.paths) ? icon.paths : [];
+    paths.forEach((pathData)=>{
+      if(!pathData) return;
+      const path = document.createElementNS(NS, 'path');
+      if(typeof pathData === 'string'){
+        path.setAttribute('d', pathData);
+        Object.entries(defaultPathAttrs).forEach(([k,v])=>path.setAttribute(k,v));
+      }else if(typeof pathData === 'object'){
+        if(pathData.d){ path.setAttribute('d', pathData.d); }
+        Object.entries({ ...defaultPathAttrs, ...(pathData.attrs||{}) }).forEach(([k,v])=>{
+          if(v!==undefined){ path.setAttribute(k,v); }
+        });
+      }
+      el.appendChild(path);
+    });
+    el.dataset.heroicon = name;
+  }
+
+  function refresh(root){
+    const scope = root || document;
+    scope.querySelectorAll('svg[data-heroicon]').forEach((el)=>{
+      const name = el.dataset.heroicon;
+      if(name){ applyIcon(el, name); }
+    });
+  }
+
+  window.Heroicons = {
+    apply: applyIcon,
+    refresh,
+    icons
+  };
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', ()=>refresh(document));
+  }else{
+    refresh(document);
+  }
+})();

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>
-  <script src="https://code.iconify.design/iconify-icon/1.0.8/iconify-icon.min.js" defer></script>
   <link rel="stylesheet" href="/static/style.css"/>
 </head>
 <body class="bg-slate-100">
@@ -27,7 +26,7 @@
       <div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
         <div id="session_meta_summary" class="hidden md:flex items-start gap-3 px-4 py-3 rounded-2xl bg-slate-100/90 text-xs text-slate-600 shadow-inner">
           <div class="shrink-0">
-            <iconify-icon icon="heroicons-outline:clipboard-document-list" class="w-6 h-6 text-slate-500"></iconify-icon>
+            <svg class="w-6 h-6 text-slate-500" data-heroicon="clipboard-document-list" aria-hidden="true"></svg>
           </div>
           <div class="leading-tight space-y-1">
             <p id="session_meta_primary" class="text-sm font-medium text-slate-700">暂无会话</p>
@@ -49,25 +48,25 @@
   <div class="flex flex-1">
     <aside id="sidebar" class="hidden md:flex border-r border-slate-200 bg-white/80 backdrop-blur-sm transition-all duration-300" data-collapsed="false">
       <div class="flex flex-col w-full h-full">
-        <div class="px-4 pt-6 pb-4 flex items-center justify-between">
+        <div class="sidebar-header px-4 pt-6 pb-4 flex items-center justify-between">
           <p class="nav-section-label text-xs font-semibold text-slate-400 uppercase tracking-wide">导航</p>
           <button id="sidebar_toggle" class="sidebar-toggle btn btn-ghost" type="button" aria-expanded="true" aria-label="收起侧边栏" title="收起侧边栏">
-            <iconify-icon icon="heroicons-outline:chevron-left" class="w-5 h-5"></iconify-icon>
+            <svg class="w-5 h-5" data-heroicon="chevron-left" aria-hidden="true"></svg>
           </button>
         </div>
         <nav class="flex-1 flex flex-col gap-2 px-2">
           <button class="nav-link nav-link-active" data-target="page-coding" title="编码工作台" aria-label="编码工作台">
-            <iconify-icon icon="heroicons-outline:adjustments-horizontal" class="nav-icon w-5 h-5"></iconify-icon>
+            <svg class="nav-icon w-5 h-5" data-heroicon="adjustments-horizontal" aria-hidden="true"></svg>
             <span class="nav-label">编码工作台</span>
           </button>
           <button class="nav-link" data-target="page-visual" title="数据可视化" aria-label="数据可视化">
-            <iconify-icon icon="heroicons-outline:chart-pie" class="nav-icon w-5 h-5"></iconify-icon>
+            <svg class="nav-icon w-5 h-5" data-heroicon="chart-pie" aria-hidden="true"></svg>
             <span class="nav-label">数据可视化</span>
           </button>
         </nav>
         <div class="sidebar-footer px-2 pt-4 pb-6 border-t border-slate-200">
           <button class="nav-link" data-target="page-settings" title="OpenAI API 设置" aria-label="OpenAI API 设置">
-            <iconify-icon icon="heroicons-outline:cog-6-tooth" class="nav-icon w-5 h-5"></iconify-icon>
+            <svg class="nav-icon w-5 h-5" data-heroicon="cog-6-tooth" aria-hidden="true"></svg>
             <span class="nav-label">OpenAI API 设置</span>
           </button>
         </div>
@@ -86,7 +85,7 @@
                 </div>
                 <div class="flex flex-wrap items-center gap-3">
                   <button id="btn_upload" class="action-btn bg-blue-600 text-white hover:bg-blue-500 shadow-sm" title="上传并新建会话">
-                    <iconify-icon icon="heroicons-outline:arrow-up-tray" class="w-5 h-5"></iconify-icon>
+                    <svg class="w-5 h-5" data-heroicon="arrow-up-tray" aria-hidden="true"></svg>
                     <span>上传并新建会话</span>
                   </button>
                   <div class="flex-1 min-w-[200px]">
@@ -101,19 +100,19 @@
                 <div class="text-xs uppercase tracking-wide text-slate-500">会话与导出</div>
                 <div class="grid gap-3 sm:grid-cols-2">
                   <button id="btn_save_session" class="action-btn justify-center bg-emerald-600 text-white hover:bg-emerald-500 shadow-sm" title="将当前会话写入服务器磁盘（sessions/）">
-                    <iconify-icon icon="heroicons-outline:cloud-arrow-up" class="w-5 h-5"></iconify-icon>
+                    <svg class="w-5 h-5" data-heroicon="cloud-arrow-up" aria-hidden="true"></svg>
                     <span>保存会话</span>
                   </button>
                   <button id="btn_load_session" class="action-btn justify-center bg-slate-800 text-white hover:bg-slate-700 shadow-sm" title="从服务器读取会话">
-                    <iconify-icon icon="heroicons-outline:folder-arrow-down" class="w-5 h-5"></iconify-icon>
+                    <svg class="w-5 h-5" data-heroicon="folder-arrow-down" aria-hidden="true"></svg>
                     <span>载入会话</span>
                   </button>
                   <button id="btn_save_excel" class="action-btn justify-center bg-indigo-600 text-white hover:bg-indigo-500 shadow-sm" title="写入 Output/<session>/export_*.xlsx">
-                    <iconify-icon icon="heroicons-outline:document-arrow-down" class="w-5 h-5"></iconify-icon>
+                    <svg class="w-5 h-5" data-heroicon="document-arrow-down" aria-hidden="true"></svg>
                     <span>保存 Excel</span>
                   </button>
                   <button id="btn_download_last" class="action-btn justify-center bg-slate-600 text-white hover:bg-slate-500 shadow-sm" title="从服务器下载最近一次导出副本（可选）">
-                    <iconify-icon icon="heroicons-outline:arrow-down-tray" class="w-5 h-5"></iconify-icon>
+                    <svg class="w-5 h-5" data-heroicon="arrow-down-tray" aria-hidden="true"></svg>
                     <span>下载最新导出</span>
                   </button>
                 </div>
@@ -333,6 +332,7 @@
     <button class="btn bg-slate-700 text-white hover:bg-slate-600" onclick="qs('dlg_sessions').close()">关闭</button>
   </div>
 </dialog>
+<script src="/static/heroicons.js"></script>
 <script>
 /* ===================== 全局状态 ===================== */
 let TOPIC_LIST=[], FIELD_LIST=[], ADJ_TOPIC_COL="", ADJ_FIELD_COL="";
@@ -427,9 +427,14 @@ function applySidebarState(collapsed){
     SIDEBAR_TOGGLE.setAttribute('aria-expanded', (!collapsed).toString());
     SIDEBAR_TOGGLE.title = collapsed ? '展开侧边栏' : '收起侧边栏';
     SIDEBAR_TOGGLE.setAttribute('aria-label', SIDEBAR_TOGGLE.title);
-    const icon = SIDEBAR_TOGGLE.querySelector('iconify-icon');
+    const icon = SIDEBAR_TOGGLE.querySelector('svg[data-heroicon]');
     if(icon){
-      icon.setAttribute('icon', collapsed ? 'heroicons-outline:chevron-right' : 'heroicons-outline:chevron-left');
+      const targetIcon = collapsed ? 'chevron-right' : 'chevron-left';
+      if(window.Heroicons && typeof window.Heroicons.apply === 'function'){
+        window.Heroicons.apply(icon, targetIcon);
+      }else{
+        icon.dataset.heroicon = targetIcon;
+      }
     }
   }
   try{ localStorage.setItem('sidebar_collapsed', collapsed ? '1' : '0'); }catch(e){}

--- a/static/style.css
+++ b/static/style.css
@@ -8,8 +8,8 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 .btn,
 .action-btn{ display:inline-flex; align-items:center; justify-content:center; gap:0.5rem; min-height:2.5rem; padding:0.45rem 0.95rem; border-radius:0.85rem; font-size:0.875rem; font-weight:600; line-height:1.25rem; border:1px solid transparent; transition:transform .15s ease, box-shadow .15s ease, background-color .15s ease, border-color .15s ease; }
 .btn:hover{ transform:translateY(-1px); box-shadow:0 10px 20px -18px rgba(15,23,42,0.45); }
-.btn iconify-icon,
-.action-btn iconify-icon{ width:1.25rem; height:1.25rem; color:inherit; flex-shrink:0; display:block; }
+.btn svg[data-heroicon],
+.action-btn svg[data-heroicon]{ width:1.25rem; height:1.25rem; color:inherit; flex-shrink:0; display:block; }
 .btn:focus-visible,
 .action-btn:focus-visible{ outline:2px solid rgba(14,116,144,0.6); outline-offset:2px; }
 .btn:disabled,
@@ -30,24 +30,26 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 
 
 .nav-link{display:flex;align-items:center;gap:0.75rem;width:100%;padding:0.75rem 1rem;border-radius:0.9rem;font-weight:600;color:#475569;background:transparent;transition:background-color .15s ease,color .15s ease,transform .15s ease,box-shadow .15s ease;overflow:hidden;}
-.nav-link iconify-icon{width:1.25rem;height:1.25rem;color:inherit;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;margin:0;}
+.nav-link svg[data-heroicon]{width:1.25rem;height:1.25rem;color:inherit;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;margin:0;}
 .nav-link:hover{color:#0f172a;background-color:rgba(148,163,184,0.16);transform:translateX(2px);}
 .nav-link-active{color:#fff;background:linear-gradient(135deg,#1e293b 0%,#0f172a 100%);box-shadow:0 18px 35px -25px rgba(15,23,42,0.8);transform:none;}
 .nav-link-active:hover{color:#fff;}
 
 #sidebar{width:16rem;overflow:hidden;position:sticky;top:var(--header-offset,0px);height:calc(100vh - var(--header-offset,0px));max-height:calc(100vh - var(--header-offset,0px));transition:width .25s ease,top .2s ease,height .2s ease;overflow-y:auto;}
 #sidebar>div{height:100%;}
-#sidebar .nav-label{display:inline-flex;align-items:center;white-space:nowrap;max-width:100%;opacity:1;transform:translateX(0);transition:opacity .2s ease,transform .2s ease,max-width .2s ease;overflow:hidden;}
-#sidebar .nav-section-label{display:block;opacity:1;transform:translateY(0);transition:opacity .2s ease,transform .2s ease,max-height .2s ease;max-height:2.5rem;overflow:hidden;}
+#sidebar .nav-label{display:inline-flex;align-items:center;white-space:nowrap;max-width:100%;opacity:1;transform:translateX(0);overflow:hidden;transition:none;}
+#sidebar .nav-section-label{display:block;opacity:1;transform:translateY(0);max-height:2.5rem;overflow:hidden;transition:none;white-space:nowrap;flex-shrink:0;}
+#sidebar .sidebar-header{width:100%;}
+#sidebar[data-collapsed="true"] .sidebar-header{justify-content:center!important;}
 #sidebar .sidebar-footer{display:flex;flex-direction:column;gap:0.5rem;}
 #sidebar .sidebar-toggle{display:inline-flex;align-items:center;justify-content:center;width:2.5rem;height:2.5rem;border-radius:9999px;background-color:rgba(148,163,184,0.18);color:#1e293b;transition:background-color .2s ease,transform .2s ease;}
 #sidebar .sidebar-toggle:hover{background-color:rgba(148,163,184,0.32);transform:translateX(1px);}
-#sidebar[data-collapsed="true"]{width:5.25rem;transition:none;}
+#sidebar[data-collapsed="true"]{width:5.25rem;}
 #sidebar[data-collapsed="true"] > div{align-items:center;justify-content:center;padding-left:1rem;padding-right:1rem;}
 #sidebar[data-collapsed="true"] nav{align-items:center;justify-content:center;padding-left:0;padding-right:0;}
 #sidebar[data-collapsed="true"] .sidebar-footer{justify-content:center;padding-left:0;padding-right:0;padding-top:1.5rem;}
 #sidebar[data-collapsed="true"] .sidebar-toggle{margin-left:auto;margin-right:auto;margin-bottom:1.5rem;}
 #sidebar[data-collapsed="true"] .nav-label{max-width:0;opacity:0;transform:translateX(-0.5rem);transition:none;}
-#sidebar[data-collapsed="true"] .nav-section-label{max-height:0;opacity:0;transform:translateY(-0.5rem);margin:0;transition:none;}
+#sidebar[data-collapsed="true"] .nav-section-label{max-height:0;max-width:0;opacity:0;transform:translateY(-0.5rem);margin:0;transition:none;}
 #sidebar[data-collapsed="true"] .nav-link{justify-content:center;padding:0.9rem;gap:0;}
-#sidebar[data-collapsed="true"] .nav-link iconify-icon{margin:0;width:1.6rem;height:1.6rem;}
+#sidebar[data-collapsed="true"] .nav-link svg[data-heroicon]{margin:0;width:1.6rem;height:1.6rem;}


### PR DESCRIPTION
## Summary
- replace external Iconify dependency with a local Heroicons bundle and update icon markup
- refresh sidebar toggle logic to work with the local icons, keep width animations while removing label transitions, and center the collapse toggle in the condensed state
- update styling to support inline SVG icons, remove sub-element collapse animations, and keep the 导航 label on a single line during transitions

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e2b8019578832780c91a19c46ee7de