### PR TITLE
Refine home workspace actions layout

### DIFF
--- a/static/heroicons.js
+++ b/static/heroicons.js
@@ -1,0 +1,134 @@
+(function(){
+  // Heroicons outline icons bundled locally to avoid external network requests.
+  // Icons are sourced from https://github.com/tailwindlabs/heroicons (MIT License).
+  const NS = 'http://www.w3.org/2000/svg';
+  const defaultViewBox = '0 0 24 24';
+  const defaultStrokeWidth = 1.5;
+  const defaultPathAttrs = { 'stroke-linecap': 'round', 'stroke-linejoin': 'round' };
+
+  const icons = {
+    'clipboard-document-list': {
+      paths: [
+        "M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"
+      ]
+    },
+    'home-modern': {
+      paths: [
+        "M8.25 21v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21m0 0h4.5V3.545M12.75 21h7.5V10.75M2.25 21h1.5m18 0h-18M2.25 9l4.5-1.636M18.75 3l-1.5.545m0 6.205 3 1m1.5.5-1.5-.5M6.75 7.364V3h-3v18m3-13.636 10.5-3.819"
+      ]
+    },
+    'chevron-left': {
+      paths: [
+        "M15.75 19.5 8.25 12l7.5-7.5"
+      ]
+    },
+    'chevron-right': {
+      paths: [
+        "m8.25 4.5 7.5 7.5-7.5 7.5"
+      ]
+    },
+    'adjustments-horizontal': {
+      paths: [
+        "M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"
+      ]
+    },
+    'chart-pie': {
+      paths: [
+        "M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z",
+        "M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"
+      ]
+    },
+    'cog-6-tooth': {
+      paths: [
+        "M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z",
+        "M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+      ]
+    },
+    'lock-closed': {
+      paths: [
+        "M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+      ]
+    },
+    'lock-open': {
+      paths: [
+        "M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+      ]
+    },
+    'arrow-up-tray': {
+      paths: [
+        "M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+      ]
+    },
+    'cloud-arrow-up': {
+      paths: [
+        "M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z"
+      ]
+    },
+    'folder-arrow-down': {
+      paths: [
+        "m9 13.5 3 3m0 0 3-3m-3 3v-6m1.06-4.19-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
+      ]
+    },
+    'document-arrow-down': {
+      paths: [
+        "M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+      ]
+    },
+    'arrow-down-tray': {
+      paths: [
+        "M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+      ]
+    }
+  };
+
+  function applyIcon(el, name){
+    if(!el) return;
+    const icon = icons[name];
+    if(!icon) return;
+    while(el.firstChild){ el.removeChild(el.firstChild); }
+    const viewBox = icon.viewBox || defaultViewBox;
+    el.setAttribute('viewBox', viewBox);
+    el.setAttribute('fill', 'none');
+    el.setAttribute('stroke', 'currentColor');
+    el.setAttribute('stroke-width', icon.strokeWidth || defaultStrokeWidth);
+    if(!el.hasAttribute('aria-hidden')){
+      el.setAttribute('aria-hidden', 'true');
+    }
+    const paths = Array.isArray(icon.paths) ? icon.paths : [];
+    paths.forEach((pathData)=>{
+      if(!pathData) return;
+      const path = document.createElementNS(NS, 'path');
+      if(typeof pathData === 'string'){
+        path.setAttribute('d', pathData);
+        Object.entries(defaultPathAttrs).forEach(([k,v])=>path.setAttribute(k,v));
+      }else if(typeof pathData === 'object'){
+        if(pathData.d){ path.setAttribute('d', pathData.d); }
+        Object.entries({ ...defaultPathAttrs, ...(pathData.attrs||{}) }).forEach(([k,v])=>{
+          if(v!==undefined){ path.setAttribute(k,v); }
+        });
+      }
+      el.appendChild(path);
+    });
+    el.dataset.heroicon = name;
+  }
+
+  function refresh(root){
+    const scope = root || document;
+    scope.querySelectorAll('svg[data-heroicon]').forEach((el)=>{
+      const name = el.dataset.heroicon;
+      if(name){ applyIcon(el, name); }
+    });
+  }
+
+  window.Heroicons = {
+    apply: applyIcon,
+    refresh,
+    icons
+  };
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', ()=>refresh(document));
+  }else{
+    refresh(document);
+  }
+})();

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>
-  <script src="https://code.iconify.design/iconify-icon/1.0.8/iconify-icon.min.js" defer></script>
   <link rel="stylesheet" href="/static/style.css"/>
 </head>
 <body class="bg-slate-100">
@@ -27,7 +26,7 @@
       <div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
         <div id="session_meta_summary" class="hidden md:flex items-start gap-3 px-4 py-3 rounded-2xl bg-slate-100/90 text-xs text-slate-600 shadow-inner">
           <div class="shrink-0">
-            <iconify-icon icon="heroicons-outline:clipboard-document-list" class="w-6 h-6 text-slate-500"></iconify-icon>
+            <svg class="w-6 h-6 text-slate-500" data-heroicon="clipboard-document-list" aria-hidden="true"></svg>
           </div>
           <div class="leading-tight space-y-1">
             <p id="session_meta_primary" class="text-sm font-medium text-slate-700">暂无会话</p>
@@ -38,8 +37,9 @@
         <div class="md:hidden w-full">
           <label class="sr-only" for="mobile_page_select">页面导航</label>
           <select id="mobile_page_select" class="w-full border border-slate-200 rounded-xl px-3 py-2 text-sm text-slate-600 bg-white">
-            <option value="page-coding">编码工作台</option>
-            <option value="page-visual">数据可视化</option>
+            <option value="page-home">主页</option>
+            <option value="page-coding" data-requires-session="true">编码工作台</option>
+            <option value="page-visual" data-requires-session="true">数据可视化</option>
             <option value="page-settings">OpenAI API 设置</option>
           </select>
         </div>
@@ -49,25 +49,29 @@
   <div class="flex flex-1">
     <aside id="sidebar" class="hidden md:flex border-r border-slate-200 bg-white/80 backdrop-blur-sm transition-all duration-300" data-collapsed="false">
       <div class="flex flex-col w-full h-full">
-        <div class="px-4 pt-6 pb-4 flex items-center justify-between">
+        <div class="sidebar-header px-4 pt-6 pb-4 flex items-center justify-between">
           <p class="nav-section-label text-xs font-semibold text-slate-400 uppercase tracking-wide">导航</p>
           <button id="sidebar_toggle" class="sidebar-toggle btn btn-ghost" type="button" aria-expanded="true" aria-label="收起侧边栏" title="收起侧边栏">
-            <iconify-icon icon="heroicons-outline:chevron-left" class="w-5 h-5"></iconify-icon>
+            <svg class="w-5 h-5" data-heroicon="chevron-left" aria-hidden="true"></svg>
           </button>
         </div>
         <nav class="flex-1 flex flex-col gap-2 px-2">
-          <button class="nav-link nav-link-active" data-target="page-coding" title="编码工作台" aria-label="编码工作台">
-            <iconify-icon icon="heroicons-outline:adjustments-horizontal" class="nav-icon w-5 h-5"></iconify-icon>
+          <button class="nav-link nav-link-active" data-target="page-home" title="主页" aria-label="主页">
+            <svg class="nav-icon w-5 h-5" data-heroicon="home-modern" aria-hidden="true"></svg>
+            <span class="nav-label">主页</span>
+          </button>
+          <button class="nav-link" data-target="page-coding" data-requires-session="true" title="编码工作台" aria-label="编码工作台">
+            <svg class="nav-icon w-5 h-5" data-heroicon="adjustments-horizontal" aria-hidden="true"></svg>
             <span class="nav-label">编码工作台</span>
           </button>
-          <button class="nav-link" data-target="page-visual" title="数据可视化" aria-label="数据可视化">
-            <iconify-icon icon="heroicons-outline:chart-pie" class="nav-icon w-5 h-5"></iconify-icon>
+          <button class="nav-link" data-target="page-visual" data-requires-session="true" title="数据可视化" aria-label="数据可视化">
+            <svg class="nav-icon w-5 h-5" data-heroicon="chart-pie" aria-hidden="true"></svg>
             <span class="nav-label">数据可视化</span>
           </button>
         </nav>
         <div class="sidebar-footer px-2 pt-4 pb-6 border-t border-slate-200">
           <button class="nav-link" data-target="page-settings" title="OpenAI API 设置" aria-label="OpenAI API 设置">
-            <iconify-icon icon="heroicons-outline:cog-6-tooth" class="nav-icon w-5 h-5"></iconify-icon>
+            <svg class="nav-icon w-5 h-5" data-heroicon="cog-6-tooth" aria-hidden="true"></svg>
             <span class="nav-label">OpenAI API 设置</span>
           </button>
         </div>
@@ -75,52 +79,154 @@
     </aside>
     <div class="flex-1 overflow-y-auto">
       <main class="max-w-7xl mx-auto w-full px-6 py-8 space-y-10">
-        <section id="page-coding" class="page-section space-y-8">
-          <div class="bg-white rounded-2xl shadow p-6">
-            <div class="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:items-end">
-              <div class="space-y-4">
-                <div class="space-y-2">
-                  <label class="block text-sm font-medium text-slate-600">选择表格（.xlsx/.xls/.csv）</label>
-                  <input id="file_input" class="file-input" type="file" accept=".xlsx,.xls,.csv">
-                  <p class="text-xs text-slate-500">支持 Excel 与 CSV 文件，上传后将自动开启新的会话。</p>
-                </div>
-                <div class="flex flex-wrap items-center gap-3">
-                  <button id="btn_upload" class="action-btn bg-blue-600 text-white hover:bg-blue-500 shadow-sm" title="上传并新建会话">
-                    <iconify-icon icon="heroicons-outline:arrow-up-tray" class="w-5 h-5"></iconify-icon>
-                    <span>上传并新建会话</span>
-                  </button>
-                  <div class="flex-1 min-w-[200px]">
-                    <div class="bg-slate-100 rounded-full h-2 overflow-hidden">
-                      <div id="up_bar" class="bg-blue-600 h-2 w-0 transition-[width] duration-300"></div>
-                    </div>
-                  </div>
-                  <span id="up_msg" class="text-sm text-gray-600 whitespace-nowrap"></span>
-                </div>
+        <section id="page-home" class="page-section space-y-10">
+          <div class="home-hero rounded-3xl overflow-hidden shadow">
+            <div class="home-hero-content">
+              <div class="home-hero-text">
+                <p class="home-hero-eyebrow">CommCoder Studio</p>
+                <h2 class="home-hero-title">专业级人工编码启动中心</h2>
+                <p class="home-hero-subtitle">整理流程、载入历史会话或创建新的数据集，一站式启动精细化的分类与洞察。</p>
               </div>
-              <div class="info-card rounded-2xl p-5 space-y-4">
-                <div class="text-xs uppercase tracking-wide text-slate-500">会话与导出</div>
-                <div class="grid gap-3 sm:grid-cols-2">
-                  <button id="btn_save_session" class="action-btn justify-center bg-emerald-600 text-white hover:bg-emerald-500 shadow-sm" title="将当前会话写入服务器磁盘（sessions/）">
-                    <iconify-icon icon="heroicons-outline:cloud-arrow-up" class="w-5 h-5"></iconify-icon>
-                    <span>保存会话</span>
-                  </button>
-                  <button id="btn_load_session" class="action-btn justify-center bg-slate-800 text-white hover:bg-slate-700 shadow-sm" title="从服务器读取会话">
-                    <iconify-icon icon="heroicons-outline:folder-arrow-down" class="w-5 h-5"></iconify-icon>
-                    <span>载入会话</span>
-                  </button>
-                  <button id="btn_save_excel" class="action-btn justify-center bg-indigo-600 text-white hover:bg-indigo-500 shadow-sm" title="写入 Output/<session>/export_*.xlsx">
-                    <iconify-icon icon="heroicons-outline:document-arrow-down" class="w-5 h-5"></iconify-icon>
-                    <span>保存 Excel</span>
-                  </button>
-                  <button id="btn_download_last" class="action-btn justify-center bg-slate-600 text-white hover:bg-slate-500 shadow-sm" title="从服务器下载最近一次导出副本（可选）">
-                    <iconify-icon icon="heroicons-outline:arrow-down-tray" class="w-5 h-5"></iconify-icon>
-                    <span>下载最新导出</span>
-                  </button>
+              <div class="home-hero-aside">
+                <div class="home-hero-card">
+                  <p class="home-hero-card-title">工作台能力</p>
+                  <p class="home-hero-card-desc">批量标注 · 智能建议 · 多维可视化</p>
+                </div>
+                <div class="home-hero-card">
+                  <p class="home-hero-card-title">上线准备</p>
+                  <p class="home-hero-card-desc">推荐使用桌面宽屏以获得最佳体验</p>
                 </div>
               </div>
             </div>
           </div>
 
+          <div class="home-launch-hub space-y-8">
+            <div class="home-launch-header">
+              <div>
+                <p class="home-launch-eyebrow">Workspace Launch</p>
+                <h2 class="home-launch-title">准备工作台</h2>
+                <p class="home-launch-subtitle">上传新的数据集，或从历史会话继续，解锁编码工作台。</p>
+              </div>
+              <div class="home-launch-meta">
+                <span>当前 Session ID</span>
+                <code class="home-launch-meta-code" id="home_session_hint">—</code>
+              </div>
+            </div>
+            <div id="home_lock_hint_wrapper" class="home-lock-banner" data-state="locked">
+              <div class="home-lock-icon">
+                <svg id="home_lock_icon" class="w-5 h-5" data-heroicon="lock-closed" aria-hidden="true"></svg>
+              </div>
+              <p id="home_lock_hint" class="home-lock-hint-text">请在下方上传数据集或载入会话以解锁编码工作台与数据可视化。</p>
+            </div>
+            <div class="home-card-grid">
+              <section class="home-card home-card-primary">
+                <div class="home-card-header">
+                  <div>
+                    <p class="home-card-eyebrow">新建会话</p>
+                    <h3 class="home-card-title">上传文件并自动开启新会话</h3>
+                    <p class="home-card-subtitle">支持 Excel 与 CSV 文件，系统将为每次上传生成独立会话。</p>
+                  </div>
+                  <div class="home-card-icon">
+                    <svg class="w-7 h-7" data-heroicon="cloud-arrow-up" aria-hidden="true"></svg>
+                  </div>
+                </div>
+                <div class="home-card-body space-y-6">
+                  <div class="space-y-2">
+                    <label class="block text-sm font-medium text-slate-700">选择表格（.xlsx/.xls/.csv）</label>
+                    <input id="file_input" class="file-input" type="file" accept=".xlsx,.xls,.csv">
+                  </div>
+                  <div class="home-upload-actions">
+                    <button id="btn_upload" class="action-btn home-upload-btn" title="上传并新建会话">
+                      <svg class="w-5 h-5" data-heroicon="arrow-up-tray" aria-hidden="true"></svg>
+                      <span>上传并新建会话</span>
+                    </button>
+                    <div class="home-progress">
+                      <div class="home-progress-track">
+                        <div id="up_bar" class="home-progress-bar"></div>
+                      </div>
+                      <span id="up_msg" class="home-progress-msg"></span>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section class="home-card home-card-secondary">
+                <div class="home-card-header">
+                  <div>
+                    <p class="home-card-eyebrow">会话与导出</p>
+                    <h3 class="home-card-title">继续之前的流程或输出结果</h3>
+                    <p class="home-card-subtitle">针对不同阶段提供独立操作卡片，确保重要动作一目了然。</p>
+                  </div>
+                  <div class="home-card-icon">
+                    <svg class="w-7 h-7" data-heroicon="folder-arrow-down" aria-hidden="true"></svg>
+                  </div>
+                </div>
+                <div class="home-card-body">
+                  <div class="home-action-collection">
+                    <article class="home-action-card" data-action="save-session">
+                      <div class="home-action-head">
+                        <div class="home-action-icon bg-emerald-100 text-emerald-600">
+                          <svg class="w-6 h-6" data-heroicon="cloud-arrow-up" aria-hidden="true"></svg>
+                        </div>
+                        <div>
+                          <h4 class="home-action-title">保存当前会话</h4>
+                          <p class="home-action-desc">写入服务器 sessions/ 目录，保障进度安全。</p>
+                        </div>
+                      </div>
+                      <button id="btn_save_session" class="action-btn home-action-btn bg-emerald-600 text-white hover:bg-emerald-500 shadow-sm" title="将当前会话写入服务器磁盘（sessions/）">
+                        <span>立即保存</span>
+                      </button>
+                    </article>
+                    <article class="home-action-card" data-action="load-session">
+                      <div class="home-action-head">
+                        <div class="home-action-icon bg-slate-900/10 text-slate-900">
+                          <svg class="w-6 h-6" data-heroicon="folder-arrow-down" aria-hidden="true"></svg>
+                        </div>
+                        <div>
+                          <h4 class="home-action-title">载入历史会话</h4>
+                          <p class="home-action-desc">浏览服务器记录，快速恢复之前的工作现场。</p>
+                        </div>
+                      </div>
+                      <button id="btn_load_session" class="action-btn home-action-btn bg-slate-900 text-white hover:bg-slate-800 shadow-sm" title="从服务器读取会话">
+                        <span>选择会话</span>
+                      </button>
+                    </article>
+                    <article class="home-action-card" data-action="export-excel">
+                      <div class="home-action-head">
+                        <div class="home-action-icon bg-indigo-100 text-indigo-600">
+                          <svg class="w-6 h-6" data-heroicon="document-arrow-down" aria-hidden="true"></svg>
+                        </div>
+                        <div>
+                          <h4 class="home-action-title">导出为 Excel</h4>
+                          <p class="home-action-desc">生成 Output/&lt;session&gt;/export_*.xlsx 供分析或交付。</p>
+                        </div>
+                      </div>
+                      <button id="btn_save_excel" class="action-btn home-action-btn bg-indigo-600 text-white hover:bg-indigo-500 shadow-sm" title="写入 Output/&lt;session&gt;/export_*.xlsx">
+                        <span>生成文件</span>
+                      </button>
+                    </article>
+                    <article class="home-action-card" data-action="download-export">
+                      <div class="home-action-head">
+                        <div class="home-action-icon bg-slate-200 text-slate-700">
+                          <svg class="w-6 h-6" data-heroicon="arrow-down-tray" aria-hidden="true"></svg>
+                        </div>
+                        <div>
+                          <h4 class="home-action-title">下载最新导出</h4>
+                          <p class="home-action-desc">一键获取最近一次导出成果，导出生成后自动激活下载。</p>
+                        </div>
+                      </div>
+                      <button id="btn_download_last" class="action-btn home-action-btn bg-slate-600 text-white hover:bg-slate-500 shadow-sm" title="从服务器下载最近一次导出副本（可选）">
+                        <span>下载文件</span>
+                      </button>
+                    </article>
+                  </div>
+                  <p class="home-card-footnote">所有操作都会作用于当前会话，未解锁时将保持禁用状态。</p>
+                </div>
+              </section>
+            </div>
+          </div>
+        </section>
+
+        <section id="page-coding" class="page-section space-y-8 hidden">
           <div class="bg-white rounded-2xl shadow p-6 space-y-3">
             <div class="flex flex-wrap items-center gap-3">
               <span class="text-sm">当前仅编辑：</span>
@@ -333,6 +439,7 @@
     <button class="btn bg-slate-700 text-white hover:bg-slate-600" onclick="qs('dlg_sessions').close()">关闭</button>
   </div>
 </dialog>
+<script src="/static/heroicons.js"></script>
 <script>
 /* ===================== 全局状态 ===================== */
 let TOPIC_LIST=[], FIELD_LIST=[], ADJ_TOPIC_COL="", ADJ_FIELD_COL="";
@@ -351,7 +458,12 @@ const qs = id=>document.getElementById(id);
 const escapeHtml = s=>String(s).replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;");
 const escapeAttr = s=>escapeHtml(s).replaceAll('"','&quot;');
 const numberFormatter = new Intl.NumberFormat('zh-CN');
-const setBadge = ()=>{ qs('session_badge').textContent = "Session: " + (SESSION_ID||"—"); };
+const setBadge = ()=>{
+  const badge = qs('session_badge');
+  if(badge){ badge.textContent = "Session: " + (SESSION_ID||"—"); }
+  const homeHint = qs('home_session_hint');
+  if(homeHint){ homeHint.textContent = SESSION_ID || '—'; }
+};
 
 function renderSessionMeta(meta){
   const summary = qs('session_meta_summary');
@@ -365,6 +477,8 @@ function renderSessionMeta(meta){
     primary.textContent = '暂无会话';
     secondary.textContent = '请上传或载入数据集';
     LAST_EXPORT_URL = '';
+    refreshHomeActions();
+    updateWorkspaceAccess();
     return;
   }
   const fileName = meta.origin_filename ? meta.origin_filename : '未命名数据集';
@@ -380,6 +494,8 @@ function renderSessionMeta(meta){
   }else{
     LAST_EXPORT_URL = '';
   }
+  refreshHomeActions();
+  updateWorkspaceAccess();
 }
 
 async function refreshSessionMeta(){
@@ -427,9 +543,14 @@ function applySidebarState(collapsed){
     SIDEBAR_TOGGLE.setAttribute('aria-expanded', (!collapsed).toString());
     SIDEBAR_TOGGLE.title = collapsed ? '展开侧边栏' : '收起侧边栏';
     SIDEBAR_TOGGLE.setAttribute('aria-label', SIDEBAR_TOGGLE.title);
-    const icon = SIDEBAR_TOGGLE.querySelector('iconify-icon');
+    const icon = SIDEBAR_TOGGLE.querySelector('svg[data-heroicon]');
     if(icon){
-      icon.setAttribute('icon', collapsed ? 'heroicons-outline:chevron-right' : 'heroicons-outline:chevron-left');
+      const targetIcon = collapsed ? 'chevron-right' : 'chevron-left';
+      if(window.Heroicons && typeof window.Heroicons.apply === 'function'){
+        window.Heroicons.apply(icon, targetIcon);
+      }else{
+        icon.dataset.heroicon = targetIcon;
+      }
     }
   }
   try{ localStorage.setItem('sidebar_collapsed', collapsed ? '1' : '0'); }catch(e){}
@@ -451,21 +572,141 @@ try{
 const PAGE_SECTIONS = Array.from(document.querySelectorAll('.page-section'));
 const NAV_BUTTONS = Array.from(document.querySelectorAll('.nav-link[data-target]'));
 const MOBILE_PAGE_SELECT = document.getElementById('mobile_page_select');
+const HOME_LOCK_WRAP = document.getElementById('home_lock_hint_wrapper');
+const HOME_LOCK_HINT = document.getElementById('home_lock_hint');
+const HOME_LOCK_ICON = document.getElementById('home_lock_icon');
+const SESSION_REQUIRED_PAGES = new Set(['page-coding','page-visual']);
+const HOME_ACTION_CONFIG = [
+  { action: 'save-session', btnId: 'btn_save_session', requiresSession: true },
+  { action: 'load-session', btnId: 'btn_load_session', requiresSession: false },
+  { action: 'export-excel', btnId: 'btn_save_excel', requiresSession: true },
+  { action: 'download-export', btnId: 'btn_download_last', requiresSession: true, requiresExport: true }
+];
+let ACTIVE_PAGE = 'page-home';
 
-function activatePage(targetId){
+function pingHomeLock(){
+  if(!HOME_LOCK_WRAP) return;
+  HOME_LOCK_WRAP.classList.remove('home-lock-bounce');
+  void HOME_LOCK_WRAP.offsetWidth;
+  HOME_LOCK_WRAP.classList.add('home-lock-bounce');
+  setTimeout(()=>{
+    if(HOME_LOCK_WRAP){
+      HOME_LOCK_WRAP.classList.remove('home-lock-bounce');
+    }
+  }, 950);
+}
+
+function updateWorkspaceAccess(){
+  const hasSession = !!SESSION_ID;
+  NAV_BUTTONS.forEach(btn=>{
+    const target = btn.dataset.target;
+    const locked = SESSION_REQUIRED_PAGES.has(target) && !hasSession;
+    btn.dataset.locked = locked ? '1' : '0';
+    btn.setAttribute('aria-disabled', locked ? 'true' : 'false');
+    btn.classList.toggle('nav-link-disabled', locked);
+    if(!btn.dataset.baseTitle && btn.title){
+      btn.dataset.baseTitle = btn.title;
+    }
+    if(locked){
+      const baseTitle = btn.dataset.baseTitle || btn.title || '';
+      const lockedTitle = baseTitle ? `${baseTitle}（未解锁）` : '页面未解锁';
+      btn.title = lockedTitle;
+      btn.setAttribute('aria-label', lockedTitle);
+    }else if(btn.dataset.baseTitle){
+      btn.title = btn.dataset.baseTitle;
+      btn.setAttribute('aria-label', btn.dataset.baseTitle);
+    }
+  });
+  if(MOBILE_PAGE_SELECT){
+    Array.from(MOBILE_PAGE_SELECT.options).forEach(opt=>{
+      const locked = SESSION_REQUIRED_PAGES.has(opt.value) && !hasSession;
+      opt.disabled = locked;
+    });
+    if(SESSION_REQUIRED_PAGES.has(MOBILE_PAGE_SELECT.value) && !hasSession){
+      MOBILE_PAGE_SELECT.value = 'page-home';
+    }
+  }
+  if(!hasSession && SESSION_REQUIRED_PAGES.has(ACTIVE_PAGE)){
+    activatePage('page-home', {force:true});
+  }
+  if(HOME_LOCK_WRAP){
+    HOME_LOCK_WRAP.dataset.state = hasSession ? 'ready' : 'locked';
+  }
+  if(HOME_LOCK_HINT){
+    if(hasSession){
+      const fileName = SESSION_META?.origin_filename ? SESSION_META.origin_filename : '未命名数据集';
+      const rowsNum = (SESSION_META && typeof SESSION_META.rows === 'number' && isFinite(SESSION_META.rows)) ? `${numberFormatter.format(SESSION_META.rows)} 行` : '行数待获取';
+      HOME_LOCK_HINT.textContent = `当前会话：${fileName} · ${rowsNum}，工作台已解锁。`;
+    }else{
+      HOME_LOCK_HINT.textContent = '请在下方上传数据集或载入会话以解锁编码工作台与数据可视化。';
+    }
+  }
+  if(HOME_LOCK_ICON){
+    const iconName = hasSession ? 'lock-open' : 'lock-closed';
+    if(window.Heroicons && typeof window.Heroicons.apply === 'function'){
+      window.Heroicons.apply(HOME_LOCK_ICON, iconName);
+    }else{
+      HOME_LOCK_ICON.dataset.heroicon = iconName;
+    }
+  }
+  refreshHomeActions();
+}
+
+function refreshHomeActions(){
+  const hasSession = !!SESSION_ID;
+  const hasExport = !!LAST_EXPORT_URL;
+  HOME_ACTION_CONFIG.forEach(cfg=>{
+    const btn = document.getElementById(cfg.btnId);
+    const card = document.querySelector(`.home-action-card[data-action="${cfg.action}"]`);
+    const disabled = (cfg.requiresSession && !hasSession) || (cfg.requiresExport && !hasExport);
+    if(btn){ btn.disabled = disabled; }
+    if(card){ card.dataset.disabled = disabled ? 'true' : 'false'; }
+  });
+}
+
+function activatePage(targetId, options={}){
+  const force = options.force === true;
+  if(!force && SESSION_REQUIRED_PAGES.has(targetId) && !SESSION_ID){
+    pingHomeLock();
+    return;
+  }
   PAGE_SECTIONS.forEach(section=>section.classList.toggle('hidden', section.id !== targetId));
-  NAV_BUTTONS.forEach(btn=>btn.classList.toggle('nav-link-active', btn.dataset.target === targetId));
+  NAV_BUTTONS.forEach(btn=>{
+    const isActive = btn.dataset.target === targetId;
+    btn.classList.toggle('nav-link-active', isActive);
+  });
   if(MOBILE_PAGE_SELECT && MOBILE_PAGE_SELECT.value !== targetId){
     MOBILE_PAGE_SELECT.value = targetId;
   }
+  ACTIVE_PAGE = targetId;
 }
 
-NAV_BUTTONS.forEach(btn=>btn.addEventListener('click', ()=>activatePage(btn.dataset.target)));
+function enterWorkspace(){
+  updateWorkspaceAccess();
+  activatePage('page-coding');
+}
+
+NAV_BUTTONS.forEach(btn=>btn.addEventListener('click', ()=>{
+  if(btn.dataset.locked === '1'){
+    pingHomeLock();
+    return;
+  }
+  activatePage(btn.dataset.target);
+}));
 if(MOBILE_PAGE_SELECT){
-  MOBILE_PAGE_SELECT.addEventListener('change', e=>activatePage(e.target.value));
+  MOBILE_PAGE_SELECT.addEventListener('change', e=>{
+    const target = e.target.value;
+    if(SESSION_REQUIRED_PAGES.has(target) && !SESSION_ID){
+      e.target.value = ACTIVE_PAGE;
+      pingHomeLock();
+      return;
+    }
+    activatePage(target);
+  });
 }
 
-activatePage('page-coding');
+activatePage('page-home', {force:true});
+updateWorkspaceAccess();
 
 /* ---- 默认兜底表 ---- */
 const DEF_TOPICS = ["健康议题","经济议题","政治议题","环境议题","传播模式与行为","媒介制度与平台治理","科技议题","文化议题","宗教议题","其他议题"];
@@ -521,9 +762,10 @@ function uploadFile(){
   xhr.upload.onprogress=e=>{ if(e.lengthComputable){ const p=Math.round(e.loaded*100/e.total); bar.style.width=p+"%"; msg.textContent=p+"%"; } };
   xhr.onreadystatechange=async ()=>{ if(xhr.readyState===4){ btn.disabled=false; btn.textContent="上传并新建会话";
       if(xhr.status>=200&&xhr.status<300){ const d=JSON.parse(xhr.responseText);
-        SESSION_ID=d.session_id; setBadge(); qs('total_msg').textContent=`共 ${d.total} 行`; msg.textContent="加载成功";
+        SESSION_ID=d.session_id; setBadge(); enterWorkspace(); qs('total_msg').textContent=`共 ${d.total} 行`; msg.textContent="加载成功";
         PAGER.page=1; PAGER.size=parseInt(qs('ps_input').value||"50")||50;
         LAST_EXPORT_URL=""; // 新会话清空
+        refreshHomeActions();
         clearScatterPlot('等待计算后展示。');
         await refreshSessionMeta();
         await refreshStats(); populateFilterOptions(); CURRENT_FILTER={target:"",value:""}; CURRENT_SORT={by:"",order:""}; await loadPage();
@@ -1049,7 +1291,7 @@ async function loadSession(sid){
   const r=await fetch(`/session/load?session_id=${encodeURIComponent(sid)}`,{cache:"no-store"});
   if(!r.ok){ alert("加载失败："+await r.text()); return; }
   const j=await r.json();
-  SESSION_ID=j.session_id; setBadge(); qs('total_msg').textContent=`行数：${j.total}`;
+  SESSION_ID=j.session_id; setBadge(); enterWorkspace(); qs('total_msg').textContent=`行数：${j.total}`;
   PAGER.page=1; PAGER.size=parseInt(qs('ps_input').value||"50")||50;
   clearScatterPlot('等待计算后展示。');
   renderSessionMeta(j.meta||null);
@@ -1065,6 +1307,7 @@ async function saveExcelServer(){
   const r=await fetch("/export_excel_save",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({session_id:SESSION_ID,file_name:name||undefined})});
   if(!r.ok){ alert("导出失败："+await r.text()); return; }
   const j=await r.json(); LAST_EXPORT_URL=j.download_url||"";
+  refreshHomeActions();
   await refreshSessionMeta();
   alert("已保存到服务器：\n"+(j.saved_path||""));
 }
@@ -1077,6 +1320,7 @@ async function downloadLast(){
         const x=await info.json();
         renderSessionMeta(x.meta||SESSION_META);
         LAST_EXPORT_URL = x?.meta?.last_export_path ? `/file?path=${encodeURIComponent(x.meta.last_export_path)}` : "";
+        refreshHomeActions();
       }
     }catch(e){}
   }

--- a/static/style.css
+++ b/static/style.css
@@ -8,8 +8,8 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 .btn,
 .action-btn{ display:inline-flex; align-items:center; justify-content:center; gap:0.5rem; min-height:2.5rem; padding:0.45rem 0.95rem; border-radius:0.85rem; font-size:0.875rem; font-weight:600; line-height:1.25rem; border:1px solid transparent; transition:transform .15s ease, box-shadow .15s ease, background-color .15s ease, border-color .15s ease; }
 .btn:hover{ transform:translateY(-1px); box-shadow:0 10px 20px -18px rgba(15,23,42,0.45); }
-.btn iconify-icon,
-.action-btn iconify-icon{ width:1.25rem; height:1.25rem; color:inherit; flex-shrink:0; display:block; }
+.btn svg[data-heroicon],
+.action-btn svg[data-heroicon]{ width:1.25rem; height:1.25rem; color:inherit; flex-shrink:0; display:block; }
 .btn:focus-visible,
 .action-btn:focus-visible{ outline:2px solid rgba(14,116,144,0.6); outline-offset:2px; }
 .btn:disabled,
@@ -28,26 +28,104 @@ dialog::backdrop { background: rgba(0,0,0,.25); }
 .file-input:hover{ border-color:#2563eb; }
 .file-input:focus{ outline:none; border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.12); }
 
+.home-hero{background:linear-gradient(135deg,#0f172a 0%,#1e293b 55%,#334155 100%);color:#e2e8f0;padding:clamp(2rem,4vw,3.5rem);position:relative;}
+.home-hero-content{display:flex;flex-direction:column;gap:2.5rem;align-items:flex-start;}
+@media (min-width:1024px){.home-hero-content{flex-direction:row;align-items:center;justify-content:space-between;}}
+.home-hero-text{display:flex;flex-direction:column;gap:1rem;max-width:480px;}
+.home-hero-eyebrow{text-transform:uppercase;letter-spacing:0.24em;font-size:0.75rem;color:rgba(148,163,184,0.85);font-weight:600;}
+.home-hero-title{font-size:clamp(2rem,3vw,2.75rem);font-weight:700;color:#f8fafc;line-height:1.2;}
+.home-hero-subtitle{color:rgba(226,232,240,0.88);font-size:1rem;line-height:1.65;}
+.home-hero-aside{display:grid;gap:1rem;width:100%;}
+@media (min-width:640px){.home-hero-aside{grid-template-columns:repeat(2,minmax(0,1fr));}}
+@media (min-width:1024px){.home-hero-aside{max-width:360px;grid-template-columns:1fr;}}
+.home-hero-card{backdrop-filter:blur(10px);background:rgba(15,23,42,0.28);border:1px solid rgba(148,163,184,0.3);border-radius:1.35rem;padding:1.25rem 1.4rem;}
+.home-hero-card-title{font-size:0.875rem;font-weight:600;color:#f8fafc;margin-bottom:0.35rem;}
+.home-hero-card-desc{font-size:0.8rem;color:rgba(226,232,240,0.82);line-height:1.5;}
+
+.home-launch-hub{position:relative;display:flex;flex-direction:column;gap:2.5rem;padding:clamp(2rem,4vw,3rem);border-radius:2rem;background:linear-gradient(135deg,rgba(255,255,255,0.96) 0%,rgba(241,245,249,0.92) 100%);border:1px solid rgba(148,163,184,0.28);box-shadow:0 35px 65px -45px rgba(15,23,42,0.45);backdrop-filter:blur(12px);}
+.home-launch-header{display:flex;flex-direction:column;gap:1.5rem;justify-content:space-between;}
+@media (min-width:768px){.home-launch-header{flex-direction:row;align-items:center;}}
+.home-launch-eyebrow{text-transform:uppercase;letter-spacing:0.28em;font-size:0.72rem;font-weight:600;color:#94a3b8;margin-bottom:0.65rem;}
+.home-launch-title{font-size:clamp(1.75rem,2.4vw,2.25rem);font-weight:700;color:#0f172a;}
+.home-launch-subtitle{font-size:0.95rem;color:#475569;line-height:1.65;max-width:34rem;}
+.home-launch-meta{display:flex;flex-direction:column;gap:0.45rem;background:rgba(148,163,184,0.18);border-radius:1.1rem;border:1px solid rgba(148,163,184,0.4);padding:0.9rem 1.2rem;color:#334155;font-size:0.8125rem;font-weight:600;}
+@media (min-width:768px){.home-launch-meta{align-items:flex-end;text-align:right;}}
+.home-launch-meta span{text-transform:uppercase;font-size:0.68rem;letter-spacing:0.2em;color:#64748b;}
+.home-launch-meta-code{display:inline-flex;align-items:center;gap:0.35rem;font-family:"JetBrains Mono","Fira Code",monospace;font-weight:600;color:#0f172a;background:#fff;border-radius:0.75rem;padding:0.35rem 0.75rem;box-shadow:inset 0 0 0 1px rgba(148,163,184,0.2);}
+.home-card-grid{display:grid;gap:2rem;}
+@media (min-width:1024px){.home-card-grid{grid-template-columns:repeat(2,minmax(0,1fr));}}
+.home-card{position:relative;overflow:hidden;border-radius:1.65rem;padding:clamp(1.85rem,2.5vw,2.5rem);border:1px solid rgba(148,163,184,0.3);background:rgba(255,255,255,0.94);box-shadow:0 30px 60px -45px rgba(15,23,42,0.42);display:flex;flex-direction:column;gap:2rem;min-height:100%;}
+.home-card::before{content:"";position:absolute;inset:0;pointer-events:none;opacity:0.95;}
+.home-card-primary::before{background:linear-gradient(135deg,rgba(37,99,235,0.18) 0%,rgba(14,165,233,0.16) 55%,rgba(59,130,246,0.18) 100%);}
+.home-card-secondary::before{background:linear-gradient(135deg,rgba(15,23,42,0.08) 0%,rgba(148,163,184,0.12) 60%,rgba(226,232,240,0.18) 100%);}
+.home-card>*{position:relative;z-index:1;}
+.home-card-header{display:flex;flex-direction:column;gap:1.5rem;justify-content:space-between;}
+@media (min-width:640px){.home-card-header{flex-direction:row;align-items:flex-start;}}
+.home-card-eyebrow{text-transform:uppercase;letter-spacing:0.24em;font-size:0.7rem;font-weight:600;color:rgba(15,23,42,0.55);margin-bottom:0.4rem;}
+.home-card-title{font-size:1.4rem;font-weight:700;color:#0f172a;line-height:1.3;}
+.home-card-subtitle{font-size:0.92rem;color:#475569;line-height:1.65;max-width:32rem;}
+.home-card-icon{display:inline-flex;align-items:center;justify-content:center;width:3.5rem;height:3.5rem;border-radius:1.4rem;box-shadow:0 20px 45px -30px rgba(15,23,42,0.55);}
+.home-card-primary .home-card-icon{background:rgba(37,99,235,0.2);color:#1d4ed8;}
+.home-card-secondary .home-card-icon{background:rgba(15,23,42,0.16);color:#0f172a;}
+.home-card-body{display:flex;flex-direction:column;gap:1.5rem;}
+.home-upload-actions{display:grid;gap:1rem;}
+@media (min-width:640px){.home-upload-actions{grid-template-columns:auto 1fr;align-items:center;}}
+.home-upload-btn{width:100%;background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%);color:#fff;box-shadow:0 18px 40px -22px rgba(37,99,235,0.55);}
+.home-upload-btn:hover{background:linear-gradient(135deg,#1d4ed8 0%,#1e40af 100%);}
+.home-progress{display:flex;flex-direction:column;gap:0.5rem;width:100%;}
+.home-progress-track{height:0.6rem;border-radius:9999px;background:rgba(255,255,255,0.7);border:1px solid rgba(37,99,235,0.25);overflow:hidden;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);}
+.home-progress-bar{height:100%;width:0;background:linear-gradient(90deg,#38bdf8 0%,#2563eb 100%);transition:width .35s ease;border-radius:inherit;}
+.home-progress-msg{font-size:0.8125rem;color:#1e293b;min-height:1rem;white-space:nowrap;}
+.home-action-collection{display:grid;gap:1.25rem;}
+@media (min-width:768px){.home-action-collection{grid-template-columns:repeat(2,minmax(0,1fr));}}
+.home-action-card{display:flex;flex-direction:column;gap:1.2rem;padding:1.4rem 1.5rem;border-radius:1.35rem;background:linear-gradient(160deg,rgba(248,250,252,0.92) 0%,rgba(241,245,249,0.85) 55%,rgba(226,232,240,0.9) 100%);border:1px solid rgba(148,163,184,0.28);box-shadow:0 28px 45px -36px rgba(15,23,42,0.6);min-height:100%;}
+.home-action-card[data-disabled="true"]{opacity:0.55;box-shadow:0 12px 30px -32px rgba(15,23,42,0.55);}
+.home-action-head{display:flex;align-items:flex-start;gap:1rem;}
+.home-action-icon{display:inline-flex;align-items:center;justify-content:center;width:3rem;height:3rem;border-radius:1.1rem;box-shadow:0 12px 28px -20px rgba(15,23,42,0.45);}
+.home-action-card[data-disabled="true"] .home-action-icon{box-shadow:none;}
+.home-action-title{font-size:1.1rem;font-weight:700;color:#0f172a;margin-bottom:0.35rem;}
+.home-action-desc{font-size:0.9rem;line-height:1.55;color:#475569;}
+.home-action-btn{width:100%;justify-content:center;gap:0.65rem;min-height:3.25rem;font-size:0.95rem;border-radius:1rem;}
+.home-action-btn span{flex:1;text-align:center;}
+.home-card-footnote{font-size:0.78rem;color:#64748b;line-height:1.5;}
+
+.home-lock-banner{display:flex;align-items:center;gap:0.75rem;border-radius:1.25rem;padding:0.85rem 1.1rem;border:1px solid rgba(148,163,184,0.3);background:rgba(241,245,249,0.75);transition:background .25s ease,border-color .25s ease,box-shadow .25s ease;}
+.home-lock-banner[data-state="locked"]{background:rgba(248,113,113,0.08);border-color:rgba(248,113,113,0.35);box-shadow:0 12px 32px -24px rgba(248,113,113,0.65);}
+.home-lock-banner[data-state="ready"]{background:rgba(34,197,94,0.08);border-color:rgba(34,197,94,0.35);box-shadow:0 12px 32px -24px rgba(34,197,94,0.45);}
+.home-lock-icon{display:inline-flex;align-items:center;justify-content:center;width:2.3rem;height:2.3rem;border-radius:9999px;background:rgba(15,23,42,0.12);color:#0f172a;flex-shrink:0;}
+.home-lock-banner[data-state="locked"] .home-lock-icon{background:rgba(248,113,113,0.15);color:#dc2626;}
+.home-lock-banner[data-state="ready"] .home-lock-icon{background:rgba(34,197,94,0.18);color:#047857;}
+.home-lock-hint-text{font-size:0.875rem;color:#334155;line-height:1.55;}
+.home-lock-banner[data-state="ready"] .home-lock-hint-text{color:#065f46;}
+.home-lock-bounce{animation:homeLockPulse 0.9s ease;}
+.home-lock-banner[data-state="ready"].home-lock-bounce{animation:homeLockPulseReady 0.9s ease;}
+@keyframes homeLockPulse{0%{box-shadow:0 0 0 0 rgba(248,113,113,0.45);}60%{box-shadow:0 0 0 10px rgba(248,113,113,0);}100%{box-shadow:0 0 0 0 rgba(248,113,113,0);}}
+@keyframes homeLockPulseReady{0%{box-shadow:0 0 0 0 rgba(34,197,94,0.35);}60%{box-shadow:0 0 0 10px rgba(34,197,94,0);}100%{box-shadow:0 0 0 0 rgba(34,197,94,0);}}
+
 
 .nav-link{display:flex;align-items:center;gap:0.75rem;width:100%;padding:0.75rem 1rem;border-radius:0.9rem;font-weight:600;color:#475569;background:transparent;transition:background-color .15s ease,color .15s ease,transform .15s ease,box-shadow .15s ease;overflow:hidden;}
-.nav-link iconify-icon{width:1.25rem;height:1.25rem;color:inherit;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;margin:0;}
+.nav-link svg[data-heroicon]{width:1.25rem;height:1.25rem;color:inherit;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;margin:0;}
 .nav-link:hover{color:#0f172a;background-color:rgba(148,163,184,0.16);transform:translateX(2px);}
 .nav-link-active{color:#fff;background:linear-gradient(135deg,#1e293b 0%,#0f172a 100%);box-shadow:0 18px 35px -25px rgba(15,23,42,0.8);transform:none;}
 .nav-link-active:hover{color:#fff;}
+.nav-link-disabled{cursor:not-allowed;opacity:0.5;box-shadow:none;transform:none;}
+.nav-link-disabled:hover{background:transparent;color:#475569;transform:none;}
 
 #sidebar{width:16rem;overflow:hidden;position:sticky;top:var(--header-offset,0px);height:calc(100vh - var(--header-offset,0px));max-height:calc(100vh - var(--header-offset,0px));transition:width .25s ease,top .2s ease,height .2s ease;overflow-y:auto;}
 #sidebar>div{height:100%;}
-#sidebar .nav-label{display:inline-flex;align-items:center;white-space:nowrap;max-width:100%;opacity:1;transform:translateX(0);transition:opacity .2s ease,transform .2s ease,max-width .2s ease;overflow:hidden;}
-#sidebar .nav-section-label{display:block;opacity:1;transform:translateY(0);transition:opacity .2s ease,transform .2s ease,max-height .2s ease;max-height:2.5rem;overflow:hidden;}
+#sidebar .nav-label{display:inline-flex;align-items:center;white-space:nowrap;max-width:100%;opacity:1;transform:translateX(0);overflow:hidden;transition:none;}
+#sidebar .nav-section-label{display:block;opacity:1;transform:translateY(0);max-height:2.5rem;overflow:hidden;transition:none;white-space:nowrap;flex-shrink:0;}
+#sidebar .sidebar-header{width:100%;}
+#sidebar[data-collapsed="true"] .sidebar-header{justify-content:center!important;}
 #sidebar .sidebar-footer{display:flex;flex-direction:column;gap:0.5rem;}
 #sidebar .sidebar-toggle{display:inline-flex;align-items:center;justify-content:center;width:2.5rem;height:2.5rem;border-radius:9999px;background-color:rgba(148,163,184,0.18);color:#1e293b;transition:background-color .2s ease,transform .2s ease;}
 #sidebar .sidebar-toggle:hover{background-color:rgba(148,163,184,0.32);transform:translateX(1px);}
-#sidebar[data-collapsed="true"]{width:5.25rem;transition:none;}
+#sidebar[data-collapsed="true"]{width:5.25rem;}
 #sidebar[data-collapsed="true"] > div{align-items:center;justify-content:center;padding-left:1rem;padding-right:1rem;}
 #sidebar[data-collapsed="true"] nav{align-items:center;justify-content:center;padding-left:0;padding-right:0;}
 #sidebar[data-collapsed="true"] .sidebar-footer{justify-content:center;padding-left:0;padding-right:0;padding-top:1.5rem;}
 #sidebar[data-collapsed="true"] .sidebar-toggle{margin-left:auto;margin-right:auto;margin-bottom:1.5rem;}
 #sidebar[data-collapsed="true"] .nav-label{max-width:0;opacity:0;transform:translateX(-0.5rem);transition:none;}
-#sidebar[data-collapsed="true"] .nav-section-label{max-height:0;opacity:0;transform:translateY(-0.5rem);margin:0;transition:none;}
+#sidebar[data-collapsed="true"] .nav-section-label{max-height:0;max-width:0;opacity:0;transform:translateY(-0.5rem);margin:0;transition:none;}
 #sidebar[data-collapsed="true"] .nav-link{justify-content:center;padding:0.9rem;gap:0;}
-#sidebar[data-collapsed="true"] .nav-link iconify-icon{margin:0;width:1.6rem;height:1.6rem;}
+#sidebar[data-collapsed="true"] .nav-link svg[data-heroicon]{margin:0;width:1.6rem;height:1.6rem;}


### PR DESCRIPTION
## Summary
- restyle the home "会话与导出" area as a grid of prominent action cards with refreshed copy and iconography
- add client-side state management to disable session-dependent actions and reflect their availability in the new cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b8019578832780c91a19c46ee7de