### PR TITLE
Overlay adjusted classification charts on visualization tabs

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -367,22 +367,48 @@
               <h3 class="font-semibold">分类概览（点击类别即可筛选）</h3>
               <div class="text-sm text-gray-500" id="total_msg">—</div>
             </div>
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div>
-                <div class="flex items-center justify-between">
-                  <h4 class="text-sm font-semibold">研究主题（原）</h4>
-                  <button class="text-xs text-sky-700" id="btn_only_other_topic">只看『其他议题』</button>
+            <div class="vis-tab-toggle" role="tablist">
+              <button id="btn_vis_tab_orig" class="vis-tab-btn" role="tab" aria-selected="true" data-vis-tab="orig">原始分类</button>
+              <button id="btn_vis_tab_adj" class="vis-tab-btn" role="tab" aria-selected="false" data-vis-tab="adj">调整后分类</button>
+            </div>
+            <div id="vis_panel_orig" class="vis-tab-panel" data-vis-panel="orig">
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div>
+                  <div class="flex items-center justify-between">
+                    <h4 class="text-sm font-semibold">研究主题（原）</h4>
+                    <button class="text-xs text-sky-700" id="btn_only_other_topic_orig">只看『其他议题』</button>
+                  </div>
+                  <div id="chips_topic_orig" class="flex flex-wrap gap-2 my-2"></div>
+                  <canvas id="chart_topic_orig" data-chart-key="chart_topic_orig" height="140"></canvas>
                 </div>
-                <div id="chips_topic_orig" class="flex flex-wrap gap-2 my-2"></div>
-                <canvas id="chart_topic_orig" height="140"></canvas>
+                <div>
+                  <div class="flex items-center justify-between">
+                    <h4 class="text-sm font-semibold">研究领域（原）</h4>
+                    <button class="text-xs text-sky-700" id="btn_only_other_field_orig">只看『其他领域』</button>
+                  </div>
+                  <div id="chips_field_orig" class="flex flex-wrap gap-2 my-2"></div>
+                  <canvas id="chart_field_orig" data-chart-key="chart_field_orig" height="140"></canvas>
+                </div>
               </div>
-              <div>
-                <div class="flex items-center justify-between">
-                  <h4 class="text-sm font-semibold">研究领域（原）</h4>
-                  <button class="text-xs text-sky-700" id="btn_only_other_field">只看『其他领域』</button>
+            </div>
+            <div id="vis_panel_adj" class="vis-tab-panel hidden" data-vis-panel="adj">
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div>
+                  <div class="flex items-center justify-between">
+                    <h4 class="text-sm font-semibold">研究主题（调整后）</h4>
+                    <button class="text-xs text-sky-700" id="btn_only_other_topic_adj">只看『其他议题』</button>
+                  </div>
+                  <div id="chips_topic_adj" class="flex flex-wrap gap-2 my-2"></div>
+                  <canvas id="chart_topic_adj" data-chart-key="chart_topic_adj" height="140"></canvas>
                 </div>
-                <div id="chips_field_orig" class="flex flex-wrap gap-2 my-2"></div>
-                <canvas id="chart_field_orig" height="140"></canvas>
+                <div>
+                  <div class="flex items-center justify-between">
+                    <h4 class="text-sm font-semibold">研究领域（调整后）</h4>
+                    <button class="text-xs text-sky-700" id="btn_only_other_field_adj">只看『其他领域』</button>
+                  </div>
+                  <div id="chips_field_adj" class="flex flex-wrap gap-2 my-2"></div>
+                  <canvas id="chart_field_adj" data-chart-key="chart_field_adj" height="140"></canvas>
+                </div>
               </div>
             </div>
           </div>
@@ -476,13 +502,14 @@ let SESSION_ID=""; let SESSION_META=null; let CURRENT_FILTER={target:"",value:""
 let ACTIVE_COL="topic"; // "topic"|"field"
 const PAGER = { page:1, size:50, total:0, pages:1 };
 let LAST_EXPORT_URL=""; // 可选下载地址
-let _ct1=null, _ct2=null;
+const BAR_CHARTS={};
 let RANK_VIS_EXPANDED=false;
 let AUTO_SAVE_TIMER=null;
 let AUTO_SAVE_ENABLED=false;
 let AUTO_SAVE_MINUTES=5;
 let IS_BATCH_SAVING=false;
 let HAS_RANKING_DATA=false;
+let VISUAL_TAB='orig';
 
 const SORT_VALUE_DEFAULT='default';
 const SORT_VALUE_RANK_ASC='rank_asc';
@@ -906,19 +933,113 @@ function uploadFile(){
 }
 
 /* ===================== 统计/图表/筛选 ===================== */
-function renderChips(elId,arr,targetKey){
-  const el=qs(elId); el.innerHTML=""; (arr||[]).forEach(it=>{
-    const b=document.createElement("button"); b.className="chip text-sm";
-    b.textContent=`${it.label}（${it.count} | ${it.percent}%）`; b.onclick=()=>quickFilter(targetKey,it.label); el.appendChild(b);
+function renderChips(elId,arr,targetKey,options={}){
+  const el=qs(elId); if(!el) return; el.innerHTML="";
+  const overlayList=Array.isArray(options.overlay)?options.overlay:[];
+  const overlayMap=new Map(overlayList.map(item=>[String(item?.label??''), item]));
+  const formatPercent=v=>{
+    if(v===undefined||v===null||v==='') return '';
+    const num=Number(v);
+    if(Number.isFinite(num)) return `${num.toFixed(2)}%`;
+    const text=String(v);
+    return text.includes('%')?text:`${text}%`;
+  };
+  (arr||[]).forEach(it=>{
+    if(!it) return;
+    const label=String(it.label??'未命名');
+    const btn=document.createElement('button'); btn.className='chip text-sm';
+    const primaryCount = Number(it.count??0);
+    const primaryPercent = formatPercent(it.percent);
+    const overlayItem=overlayMap.get(label);
+    const primaryPrefix = options.primaryLabel?`${options.primaryLabel}：`:'';
+    const overlayPrefix = options.overlayLabel?`${options.overlayLabel}：`:'';
+    const primaryParts=[`${primaryPrefix}${primaryCount}`];
+    if(primaryPercent) primaryParts.push(primaryPercent);
+    const displayParts=[primaryParts.join(' | ')];
+    if(overlayItem){
+      const overlayCount=Number(overlayItem.count??0);
+      const overlayPercent=formatPercent(overlayItem.percent);
+      const overlayParts=[`${overlayPrefix}${overlayCount}`];
+      if(overlayPercent) overlayParts.push(overlayPercent);
+      displayParts.push(overlayParts.join(' | '));
+    }
+    btn.textContent=`${label}（${displayParts.join(' · ')}）`;
+    btn.onclick=()=>quickFilter(targetKey,label);
+    el.appendChild(btn);
   });
 }
-function drawBar(canvasId,arr,key){
-  const labels=(arr||[]).map(x=>x.label), counts=(arr||[]).map(x=>x.count), ctx=qs(canvasId).getContext('2d');
-  const cfg={type:'bar', data:{labels, datasets:[{label:'Count', data:counts}]}, options:{responsive:true, plugins:{legend:{display:false}}, scales:{x:{ticks:{autoSkip:false}}, y:{beginAtZero:true}}}};
-  if(key==="chart_topic_orig"&&window._ct1){ window._ct1.destroy(); }
-  if(key==="chart_field_orig"&&window._ct2){ window._ct2.destroy(); }
-  if(key==="chart_topic_orig") window._ct1=new Chart(ctx,cfg);
-  if(key==="chart_field_orig") window._ct2=new Chart(ctx,cfg);
+function drawBar(canvasId,arr,key,options={}){
+  const canvas=qs(canvasId); if(!canvas) return;
+  if(typeof Chart==='undefined'){ return; }
+  const overlayList=Array.isArray(options.overlay)?options.overlay:[];
+  const primaryList=Array.isArray(arr)?arr:[];
+  const entryMap=new Map();
+  primaryList.forEach((item,idx)=>{
+    const label=String(item?.label??`未命名${idx+1}`);
+    if(!entryMap.has(label)) entryMap.set(label,{label,order:idx});
+    const entry=entryMap.get(label); entry.primary=item; if(entry.order===undefined) entry.order=idx;
+  });
+  const baseOrder=primaryList.length;
+  overlayList.forEach((item,idx)=>{
+    const label=String(item?.label??`未命名${idx+1}`);
+    if(!entryMap.has(label)) entryMap.set(label,{label,order:baseOrder+idx});
+    const entry=entryMap.get(label); entry.overlay=item;
+  });
+  const entries=Array.from(entryMap.values()).sort((a,b)=>{
+    const ao=Number.isFinite(a.order)?a.order:Number.MAX_SAFE_INTEGER;
+    const bo=Number.isFinite(b.order)?b.order:Number.MAX_SAFE_INTEGER;
+    return ao-bo;
+  });
+  const labels=entries.map(en=>en.label);
+  const hasOverlay=overlayList.length>0;
+  const overlayColor=options.overlayColor||'rgb(37,99,235)';
+  const overlayBackground=options.overlayBackgroundColor||'rgba(37,99,235,0.45)';
+  const primaryColor=options.primaryColor||'rgb(37,99,235)';
+  const primaryBackground=options.primaryBackgroundColor||primaryColor;
+  const datasets=[];
+  if(hasOverlay){
+    datasets.push({
+      label: options.overlayLabel||'原始分类',
+      data: entries.map(en=>Number(en.overlay?.count??0)),
+      backgroundColor: overlayBackground,
+      borderColor: overlayColor,
+      borderWidth: 1,
+      maxBarThickness: 46
+    });
+  }
+  datasets.push({
+    label: options.primaryLabel||'数量',
+    data: entries.map(en=>Number(en.primary?.count??0)),
+    backgroundColor: primaryBackground,
+    borderColor: primaryColor,
+    borderWidth: 1,
+    maxBarThickness: 46
+  });
+  const cfg={
+    type:'bar',
+    data:{labels, datasets},
+    options:{
+      responsive:true,
+      maintainAspectRatio:false,
+      plugins:{
+        legend:{display:hasOverlay, labels:{usePointStyle:true}},
+        tooltip:{mode:'index', intersect:false}
+      },
+      scales:{
+        x:{ticks:{autoSkip:false, maxRotation:30, minRotation:0}, grid:{display:false}},
+        y:{beginAtZero:true, ticks:{precision:0}}
+      }
+    }
+  };
+  if(BAR_CHARTS[key]){
+    BAR_CHARTS[key].data.labels=labels;
+    BAR_CHARTS[key].data.datasets=datasets;
+    BAR_CHARTS[key].options=cfg.options;
+    BAR_CHARTS[key].update();
+  }else{
+    const ctx=canvas.getContext('2d');
+    BAR_CHARTS[key]=new Chart(ctx,cfg);
+  }
 }
 async function refreshStats(){
   if(!SESSION_ID) return;
@@ -926,13 +1047,21 @@ async function refreshStats(){
   const d=await r.json();
   renderChips("chips_topic_orig", d.topic_orig, "topic_orig");
   renderChips("chips_field_orig", d.field_orig, "field_orig");
-  drawBar("chart_topic_orig", d.topic_orig, "chart_topic_orig");
-  drawBar("chart_field_orig", d.field_orig, "chart_field_orig");
+  renderChips("chips_topic_adj", d.topic_adj, "topic_adj", { overlay:d.topic_orig, primaryLabel:'调整后', overlayLabel:'原始' });
+  renderChips("chips_field_adj", d.field_adj, "field_adj", { overlay:d.field_orig, primaryLabel:'调整后', overlayLabel:'原始' });
+  drawBar("chart_topic_orig", d.topic_orig, "chart_topic_orig", { primaryLabel:'原始分类', primaryColor:'rgb(37,99,235)', primaryBackgroundColor:'rgba(37,99,235,0.85)' });
+  drawBar("chart_field_orig", d.field_orig, "chart_field_orig", { primaryLabel:'原始分类', primaryColor:'rgb(37,99,235)', primaryBackgroundColor:'rgba(37,99,235,0.85)' });
+  drawBar("chart_topic_adj", d.topic_adj, "chart_topic_adj", { overlay:d.topic_orig, primaryLabel:'调整后', overlayLabel:'原始', primaryColor:'rgb(239,68,68)', primaryBackgroundColor:'rgba(239,68,68,0.85)', overlayColor:'rgb(37,99,235)', overlayBackgroundColor:'rgba(37,99,235,0.45)' });
+  drawBar("chart_field_adj", d.field_adj, "chart_field_adj", { overlay:d.field_orig, primaryLabel:'调整后', overlayLabel:'原始', primaryColor:'rgb(239,68,68)', primaryBackgroundColor:'rgba(239,68,68,0.85)', overlayColor:'rgb(37,99,235)', overlayBackgroundColor:'rgba(37,99,235,0.45)' });
   qs('total_msg').textContent=`行数：${d.total}`;
 
-  if(!TOPIC_LIST.length){ TOPIC_LIST=(d.topic_orig||[]).map(x=>x.label); if(!TOPIC_LIST.length) TOPIC_LIST=[...DEF_TOPICS]; }
-  if(!FIELD_LIST.length){ FIELD_LIST=(d.field_orig||[]).map(x=>x.label); if(!FIELD_LIST.length) FIELD_LIST=[...DEF_FIELDS]; }
+  const collectLabels=arr=>Array.isArray(arr)?arr.map(x=>x.label).filter(Boolean):[];
+  const topicLabels=[...collectLabels(d.topic_orig), ...collectLabels(d.topic_adj)];
+  const fieldLabels=[...collectLabels(d.field_orig), ...collectLabels(d.field_adj)];
+  TOPIC_LIST=topicLabels.length?Array.from(new Set(topicLabels)):[...DEF_TOPICS];
+  FIELD_LIST=fieldLabels.length?Array.from(new Set(fieldLabels)):[...DEF_FIELDS];
   populateFilterOptions();
+  setVisualTab(VISUAL_TAB||'orig');
 }
 
 function clearScatterPlot(message){
@@ -940,6 +1069,30 @@ function clearScatterPlot(message){
   if(plotEl && window.Plotly){ try{ Plotly.purge(plotEl); }catch(e){} }
   if(plotEl) plotEl.innerHTML="";
   const msg=qs('rank_vis_msg'); if(msg) msg.textContent=message||'等待计算后展示。';
+}
+
+function setVisualTab(tab){
+  const target = tab==='adj' ? 'adj' : 'orig';
+  VISUAL_TAB = target;
+  document.querySelectorAll('[data-vis-panel]').forEach(panel=>{
+    const active = panel.dataset?.visPanel===target;
+    panel.classList.toggle('hidden', !active);
+    if(active){ panel.classList.remove('opacity-0'); }
+  });
+  const activePanel=document.querySelector(`[data-vis-panel="${target}"]`);
+  if(activePanel){
+    activePanel.querySelectorAll('canvas[data-chart-key]').forEach(cv=>{
+      const key=cv.dataset.chartKey;
+      const chart=BAR_CHARTS[key];
+      if(chart && typeof chart.resize==='function'){ try{ chart.resize(); }catch(e){} }
+    });
+  }
+  document.querySelectorAll('[data-vis-tab]').forEach(btn=>{
+    const active = btn.dataset?.visTab===target;
+    btn.classList.toggle('vis-tab-btn-active', active);
+    btn.setAttribute('aria-selected', active? 'true':'false');
+    btn.tabIndex = active?0:-1;
+  });
 }
 
 function setRankVisExpanded(expanded){
@@ -1579,8 +1732,10 @@ function bindEvents(){
   const autoInterval=qs('auto_save_interval'); if(autoInterval) autoInterval.addEventListener('change', applyAutoSaveSettings);
 
   // 筛选
-  qs('btn_only_other_topic').onclick=()=>quickFilter('topic_orig','其他议题');
-  qs('btn_only_other_field').onclick=()=>quickFilter('field_orig','其他领域');
+  const btnOtherTopicOrig=qs('btn_only_other_topic_orig'); if(btnOtherTopicOrig) btnOtherTopicOrig.onclick=()=>quickFilter('topic_orig','其他议题');
+  const btnOtherFieldOrig=qs('btn_only_other_field_orig'); if(btnOtherFieldOrig) btnOtherFieldOrig.onclick=()=>quickFilter('field_orig','其他领域');
+  const btnOtherTopicAdj=qs('btn_only_other_topic_adj'); if(btnOtherTopicAdj) btnOtherTopicAdj.onclick=()=>quickFilter('topic_adj','其他议题');
+  const btnOtherFieldAdj=qs('btn_only_other_field_adj'); if(btnOtherFieldAdj) btnOtherFieldAdj.onclick=()=>quickFilter('field_adj','其他领域');
   qs('btn_apply_filter').onclick=()=>{
     CURRENT_FILTER={ target:qs('filter_target').value, value:qs('filter_value').value };
     PAGER.page=1;
@@ -1603,7 +1758,10 @@ function bindEvents(){
   qs('btn_do_ranking').onclick=doRanking;
   const btnRefreshVis=qs('btn_refresh_vis'); if(btnRefreshVis) btnRefreshVis.onclick=()=>fetchScatterAndRender(true);
   const btnToggleVis=qs('btn_toggle_vis'); if(btnToggleVis) btnToggleVis.onclick=toggleRankVis;
+  const tabOrig=qs('btn_vis_tab_orig'); if(tabOrig) tabOrig.onclick=()=>setVisualTab('orig');
+  const tabAdj=qs('btn_vis_tab_adj'); if(tabAdj) tabAdj.onclick=()=>setVisualTab('adj');
   setRankVisExpanded(false);
+  setVisualTab('orig');
   qs('rank_algo').addEventListener('change', handleAlgoChange);
   handleAlgoChange();
 

--- a/static/style.css
+++ b/static/style.css
@@ -3,6 +3,13 @@
 .cell-outlier    { background-color:#FFDAD6; } /* 淡红：离群 */
 .chip{ padding:2px 8px; border-radius:9999px; background:#f1f5f9; }
 .chip:hover{ background:#e2e8f0; }
+.vis-tab-toggle{ display:flex; gap:0.75rem; padding-bottom:0.5rem; margin-bottom:1.5rem; border-bottom:1px solid rgba(148,163,184,0.35); }
+.vis-tab-btn{ position:relative; padding:0.35rem 0.9rem; border-radius:9999px; font-size:0.85rem; font-weight:600; color:#475569; background:rgba(148,163,184,0.12); transition:background-color .15s ease,color .15s ease,box-shadow .15s ease; }
+.vis-tab-btn:hover{ background:rgba(148,163,184,0.24); color:#1e293b; }
+.vis-tab-btn-active,
+.vis-tab-btn[aria-selected="true"]{ background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%); color:#fff; box-shadow:0 12px 24px -20px rgba(37,99,235,0.6); }
+.vis-tab-panel{ transition:opacity .15s ease; }
+.vis-tab-panel.hidden{ opacity:0; }
 :root{ --header-offset:0px; }
 dialog::backdrop { background: rgba(0,0,0,.25); }
 .btn,


### PR DESCRIPTION
## Summary
- add tab controls so the visualization panel can switch between original and adjusted classifications
- render bar charts and quick filters for both classification sets while keeping filter options in sync
- overlay adjusted classification counts on top of the original distributions and update chips so the full dataset stays visible in the adjusted view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3b2cd37dc832788fd9bd3b17d1908