### PR TITLE
Refactor scatter plot rendering to stabilize visualization layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -423,7 +423,7 @@
                 <button id="btn_refresh_vis" class="btn btn-sm bg-slate-700 text-white hover:bg-slate-600">刷新可视化</button>
               </div>
               <div id="rank_vis_msg" class="text-sm text-gray-500">等待计算后展示。</div>
-              <div id="rank_vis_plot" class="w-full h-[460px]"></div>
+              <div id="rank_vis_plot" class="w-full min-h-[320px]"></div>
             </div>
           </div>
         </section>
@@ -504,7 +504,18 @@ const PAGER = { page:1, size:50, total:0, pages:1 };
 let LAST_EXPORT_URL=""; // 可选下载地址
 const BAR_CHARTS={};
 let RANK_VIS_EXPANDED=false;
-const RANK_VIS_HEIGHT=460;
+const SCATTER_DEFAULT_HEIGHT=420;
+const SCATTER_STATE={
+  height:SCATTER_DEFAULT_HEIGHT,
+  hasData:false,
+  observer:null,
+  resizeTimer:0
+};
+const SCATTER_CONFIG={
+  displaylogo:false,
+  responsive:false,
+  modeBarButtonsToRemove:['autoScale2d','hoverClosestCartesian','hoverCompareCartesian'],
+};
 let AUTO_SAVE_TIMER=null;
 let AUTO_SAVE_ENABLED=false;
 let AUTO_SAVE_MINUTES=5;
@@ -1065,11 +1076,78 @@ async function refreshStats(){
   setVisualTab(VISUAL_TAB||'orig');
 }
 
+function getRankPlotElement(){
+  return qs('rank_vis_plot');
+}
+
+function computeScatterHeight(el){
+  const plotEl=el||getRankPlotElement();
+  if(!plotEl) return SCATTER_DEFAULT_HEIGHT;
+  const width=plotEl.clientWidth||plotEl.offsetWidth||0;
+  if(!width) return SCATTER_DEFAULT_HEIGHT;
+  const desired=Math.round(width*0.6);
+  return Math.max(320, Math.min(desired, 580));
+}
+
+function applyScatterHeight(plotEl, height){
+  if(!plotEl) return;
+  const clamped=Math.max(320, Math.round(height||SCATTER_DEFAULT_HEIGHT));
+  if(plotEl.style.height!==`${clamped}px`){
+    plotEl.style.height=`${clamped}px`;
+  }
+  SCATTER_STATE.height=clamped;
+}
+
+function scheduleScatterResize(){
+  if(!RANK_VIS_EXPANDED || !SCATTER_STATE.hasData) return;
+  if(!window.Plotly) return;
+  const plotEl=getRankPlotElement();
+  if(!plotEl) return;
+  if(SCATTER_STATE.resizeTimer){
+    cancelAnimationFrame(SCATTER_STATE.resizeTimer);
+  }
+  SCATTER_STATE.resizeTimer=requestAnimationFrame(()=>{
+    SCATTER_STATE.resizeTimer=0;
+    try{ Plotly.Plots.resize(plotEl); }catch(e){}
+  });
+}
+
+function ensureScatterObserver(){
+  const plotEl=getRankPlotElement();
+  if(!plotEl) return;
+  if(typeof ResizeObserver!=='function') return;
+  if(SCATTER_STATE.observer){
+    return;
+  }
+  SCATTER_STATE.observer=new ResizeObserver(entries=>{
+    if(!SCATTER_STATE.hasData) return;
+    for(const entry of entries){
+      if(entry.target!==plotEl) continue;
+      const nextHeight=computeScatterHeight(plotEl);
+      if(Math.abs(nextHeight-SCATTER_STATE.height)>2){
+        applyScatterHeight(plotEl,nextHeight);
+        if(window.Plotly){
+          try{ Plotly.relayout(plotEl,{height:SCATTER_STATE.height}); }catch(e){}
+        }
+      }
+    }
+    scheduleScatterResize();
+  });
+  SCATTER_STATE.observer.observe(plotEl);
+}
+
 function clearScatterPlot(message){
-  const plotEl=qs('rank_vis_plot');
+  const plotEl=getRankPlotElement();
   if(plotEl && window.Plotly){ try{ Plotly.purge(plotEl); }catch(e){} }
-  if(plotEl) plotEl.innerHTML="";
-  if(plotEl) plotEl.style.height='';
+  if(plotEl){
+    plotEl.innerHTML="";
+    plotEl.style.height='';
+  }
+  if(SCATTER_STATE.resizeTimer){
+    cancelAnimationFrame(SCATTER_STATE.resizeTimer);
+    SCATTER_STATE.resizeTimer=0;
+  }
+  SCATTER_STATE.hasData=false;
   const msg=qs('rank_vis_msg'); if(msg) msg.textContent=message||'等待计算后展示。';
 }
 
@@ -1109,13 +1187,13 @@ function setRankVisExpanded(expanded){
     btn.textContent=RANK_VIS_EXPANDED?"收起可视化":"展开可视化";
     btn.setAttribute('aria-expanded', RANK_VIS_EXPANDED?"true":"false");
   }
-  if(RANK_VIS_EXPANDED && window.Plotly){
-    const plotEl=qs('rank_vis_plot');
+  if(RANK_VIS_EXPANDED){
+    const plotEl=getRankPlotElement();
     if(plotEl){
-      requestAnimationFrame(()=>{
-        try{ Plotly.Plots.resize(plotEl); }catch(e){}
-      });
+      applyScatterHeight(plotEl, computeScatterHeight(plotEl));
     }
+    ensureScatterObserver();
+    scheduleScatterResize();
   }
 }
 
@@ -1124,78 +1202,126 @@ function toggleRankVis(){
 }
 
 function renderScatterPlot(data){
-  const plotEl=qs('rank_vis_plot'); if(!plotEl) return;
-  if(!window.Plotly){ plotEl.innerHTML='<div class="p-3 text-sm text-red-600">Plotly 未加载</div>'; return; }
+  const plotEl=getRankPlotElement(); if(!plotEl) return;
+  if(!window.Plotly){
+    plotEl.innerHTML='<div class="p-3 text-sm text-red-600">Plotly 未加载</div>';
+    SCATTER_STATE.hasData=false;
+    return;
+  }
   const coords=Array.isArray(data?.coords)?data.coords:[];
   if(!coords.length){ clearScatterPlot('暂无可视化数据'); return; }
-  const groups=Array.isArray(data.group_labels)?data.group_labels:[];
-  const outliers=(Array.isArray(data.outliers)?data.outliers:[]).map(Boolean);
+
+  const toNum=v=>{
+    const n=Number(v);
+    return Number.isFinite(n)?n:0;
+  };
+  const safeCoord=(idx,dim)=>{
+    const row=coords[idx];
+    if(!Array.isArray(row)) return 0;
+    return toNum(row[dim]??0);
+  };
+
+  const rawGroups=Array.isArray(data.groups)?data.groups:(Array.isArray(data.group_labels)?data.group_labels:[]);
+  const groups=coords.map((_,i)=>{
+    const g=rawGroups[i];
+    if(g===undefined || g===null || g==='') return '未分类';
+    return String(g);
+  });
+  const outliers=Array.isArray(data.outliers)?data.outliers.map(Boolean):coords.map(()=>false);
   const scores=Array.isArray(data.scores)?data.scores:[];
   const clusterLabels=Array.isArray(data.cluster_labels)?data.cluster_labels:[];
-  const toNum=(v)=>{ const n=Number(v); return Number.isFinite(n)?n:0; };
-  const getCoord=(idx,dim)=>{ const row=coords[idx]; if(!Array.isArray(row)) return 0; return toNum(row[dim]??0); };
+
   const hoverTexts=coords.map((_,i)=>{
-    const g=groups[i]||'未分类';
+    const groupText=escapeHtml(groups[i]||'未分类');
     const score=scores[i]!==undefined && scores[i]!==null?Number(scores[i]).toFixed(4):'';
+    const scoreTxt=score?`<br>Score：${score}`:'';
     const cluster=clusterLabels[i];
-    const status=outliers[i]?'是':'否';
     const clusterTxt=(cluster!==undefined && cluster!==null)?`<br>簇：${escapeHtml(String(cluster))}`:'';
-    return `类别：${escapeHtml(String(g))}<br>离群：${status}<br>Score：${score}${clusterTxt}`;
+    const status=outliers[i]?'是':'否';
+    return `类别：${groupText}<br>离群：${status}${scoreTxt}${clusterTxt}`;
   });
-  const groupSet=Array.from(new Set(groups.filter((_,i)=>!outliers[i])));
+
+  const palette=['#2563eb','#f97316','#10b981','#a855f7','#facc15','#ec4899','#14b8a6','#0ea5e9','#f43f5e','#6366f1'];
   const traces=[];
-  groupSet.forEach((g,idx)=>{
-    const indices=[]; groups.forEach((gg,i)=>{ if(!outliers[i] && gg===g) indices.push(i); });
-    if(!indices.length) return;
+  const normalGroups=Array.from(new Set(groups.filter((_,i)=>!outliers[i])));
+  normalGroups.forEach((g,idx)=>{
+    const indexes=[];
+    groups.forEach((name,i)=>{ if(!outliers[i] && name===g) indexes.push(i); });
+    if(!indexes.length) return;
     traces.push({
-      name: g||`簇 ${idx+1}`,
+      name:g||`簇 ${idx+1}`,
       type:'scattergl',
       mode:'markers',
-      x: indices.map(i=>getCoord(i,0)),
-      y: indices.map(i=>getCoord(i,1)),
-      text: indices.map(i=>hoverTexts[i]),
+      x:indexes.map(i=>safeCoord(i,0)),
+      y:indexes.map(i=>safeCoord(i,1)),
+      text:indexes.map(i=>hoverTexts[i]),
       hovertemplate:'%{text}<extra></extra>',
-      marker:{size:4, opacity:0.85}
+      marker:{
+        size:5,
+        opacity:0.88,
+        color:palette[idx%palette.length]
+      }
     });
   });
-  const outIdx=[]; outliers.forEach((flag,i)=>{ if(flag) outIdx.push(i); });
-  if(outIdx.length){
+
+  const outlierIdx=[];
+  outliers.forEach((flag,i)=>{ if(flag) outlierIdx.push(i); });
+  if(outlierIdx.length){
     traces.push({
       name:'离群',
       type:'scattergl',
       mode:'markers',
-      x: outIdx.map(i=>getCoord(i,0)),
-      y: outIdx.map(i=>getCoord(i,1)),
-      text: outIdx.map(i=>hoverTexts[i]),
+      x:outlierIdx.map(i=>safeCoord(i,0)),
+      y:outlierIdx.map(i=>safeCoord(i,1)),
+      text:outlierIdx.map(i=>hoverTexts[i]),
       hovertemplate:'%{text}<extra></extra>',
-      marker:{size:6, color:'#ef4444', symbol:'x', opacity:0.9}
+      marker:{size:7, color:'#ef4444', symbol:'x', opacity:0.95}
     });
   }
+
   if(!traces.length){
     traces.push({
-      name:'数据', type:'scattergl', mode:'markers',
-      x: coords.map((_,i)=>getCoord(i,0)),
-      y: coords.map((_,i)=>getCoord(i,1)),
-      text: hoverTexts,
+      name:'数据',
+      type:'scattergl',
+      mode:'markers',
+      x:coords.map((_,i)=>safeCoord(i,0)),
+      y:coords.map((_,i)=>safeCoord(i,1)),
+      text:hoverTexts,
       hovertemplate:'%{text}<extra></extra>',
-      marker:{size:4, opacity:0.85}
+      marker:{size:5, opacity:0.88, color:'#2563eb'}
     });
   }
+
+  const desiredHeight=computeScatterHeight(plotEl);
+  applyScatterHeight(plotEl, desiredHeight);
+
   const layout={
-    margin:{l:40,r:10,t:30,b:40},
-    height:RANK_VIS_HEIGHT,
-    xaxis:{title:'PC1', zeroline:false},
-    yaxis:{title:'PC2', zeroline:false},
-    legend:{orientation:'h'}
+    margin:{l:40,r:16,t:36,b:42},
+    autosize:true,
+    height:SCATTER_STATE.height,
+    hovermode:'closest',
+    legend:{orientation:'h',yanchor:'top',y:-0.18},
+    xaxis:{title:'PC1',zeroline:false},
+    yaxis:{title:'PC2',zeroline:false}
   };
-  Plotly.newPlot(plotEl, traces, layout, {responsive:true, displaylogo:false}).then(()=>{
-    try{ plotEl.style.height=RANK_VIS_HEIGHT+'px'; }catch(e){}
-    if(RANK_VIS_EXPANDED){
-      requestAnimationFrame(()=>{
-        try{ Plotly.Plots.resize(plotEl); }catch(e){}
-      });
-    }
-  });
+
+  SCATTER_STATE.hasData=true;
+  ensureScatterObserver();
+  let plotPromise;
+  try{
+    plotPromise=Plotly.react(plotEl, traces, layout, SCATTER_CONFIG);
+  }catch(err){
+    console.error('Plotly 渲染失败', err);
+    plotEl.innerHTML='<div class="p-3 text-sm text-red-600">可视化渲染失败</div>';
+    SCATTER_STATE.hasData=false;
+    return;
+  }
+  if(plotPromise && typeof plotPromise.then==='function'){
+    plotPromise.then(()=>{ scheduleScatterResize(); }).catch(()=>{});
+  }else{
+    scheduleScatterResize();
+  }
+
   const msg=qs('rank_vis_msg');
   if(msg){
     const outCount=outliers.filter(Boolean).length;


### PR DESCRIPTION
## Summary
- replace the fixed-height scatter plot implementation with a stateful renderer that computes height dynamically and reuses Plotly via `react`
- add ResizeObserver-driven resizing with throttled updates to stop the visualization container from stretching the page
- adjust the visualization container markup to drop the fixed Tailwind height utility in favor of script-controlled sizing

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3c1ae5dd483278f1788faf23aa99f